### PR TITLE
Add task rendering to getStory tool

### DIFF
--- a/src/tools/stories.test.ts
+++ b/src/tools/stories.test.ts
@@ -9,6 +9,7 @@ import type {
 	PullRequest,
 	Story,
 	StoryComment,
+	Task,
 	UpdateStory,
 	Workflow,
 } from "@shortcut/client";
@@ -77,6 +78,18 @@ describe("StoryTools", () => {
 				} as unknown as StoryComment,
 			],
 			formatted_vcs_branch_name: "user1/sc-123/test-story-1",
+			tasks: [
+				{
+					id: 1,
+					description: "task 1",
+					complete: false,
+				},
+				{
+					id: 2,
+					description: "task 2",
+					complete: true,
+				},
+			] satisfies Partial<Task>[],
 		} as unknown as Story,
 		{
 			id: 456,
@@ -217,6 +230,10 @@ describe("StoryTools", () => {
 				"",
 				"Pull Requests:",
 				"- Title: Test PR 1, Merged: Yes, URL: https://github.com/user1/repo1/pull/1",
+				"",
+				"Tasks:",
+				"[ ] task 1",
+				"[X] task 2",
 				"",
 				"Comments:",
 				"- From: @testuser on 2023-01-01T12:00:00Z.",

--- a/src/tools/stories.ts
+++ b/src/tools/stories.ts
@@ -3,7 +3,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemberInfo, Story } from "@shortcut/client";
 import { z } from "zod";
 import { BaseTools } from "./base";
-import { formatMemberList, formatPullRequestList, formatStoryList } from "./utils/format";
+import {
+	formatMemberList,
+	formatPullRequestList,
+	formatStoryList,
+	formatTaskList,
+} from "./utils/format";
 import { type QueryParams, buildSearchQuery } from "./utils/search";
 import { date, has, is, user } from "./utils/validation";
 
@@ -328,6 +333,9 @@ ${
 		? `${formatPullRequestList(story.branches)}`
 		: " [None]"
 }
+
+Tasks:
+${story.tasks && story.tasks.length > 0 ? `${formatTaskList(story.tasks)}` : " [None]"}
 
 Comments:
 ${(story.comments || [])

--- a/src/tools/utils/format.test.ts
+++ b/src/tools/utils/format.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import type { Branch, Member, PullRequest, Story, Workflow } from "@shortcut/client";
+import type { Branch, Member, PullRequest, Story, Task, Workflow } from "@shortcut/client";
 import {
 	formatMemberList,
 	formatPullRequestList,
 	formatStoryList,
+	formatTaskList,
 	formatWorkflowList,
 } from "./format";
 
@@ -115,6 +116,11 @@ const mockBranches = [
 		],
 	} as Branch,
 ];
+
+const mockTasks = [
+	{ description: "task 1", complete: false },
+	{ description: "task 2", complete: true },
+] satisfies Partial<Task>[] as Task[];
 
 describe("formatStoryList", () => {
 	test("should return empty string for empty stories array", () => {
@@ -308,5 +314,10 @@ describe("formatPullRequestList", () => {
 				"- Title: Test PR 2, Merged: No, URL: https://github.com/user1/repo1/pull/2",
 			].join("\n"),
 		);
+	});
+
+	test("should format task lists", () => {
+		const result = formatTaskList(mockTasks);
+		expect(result).toBe(["[ ] task 1", "[X] task 2"].join("\n"));
 	});
 });

--- a/src/tools/utils/format.ts
+++ b/src/tools/utils/format.ts
@@ -1,4 +1,4 @@
-import type { Branch, Member, Story, StorySearchResult, Workflow } from "@shortcut/client";
+import type { Branch, Member, Story, StorySearchResult, Task, Workflow } from "@shortcut/client";
 
 export const formatStoryList = (
 	stories: (Story | StorySearchResult)[],
@@ -45,6 +45,14 @@ export const formatPullRequestList = (branches: Branch[]) => {
 		.flatMap((branch) => branch.pull_requests || [])
 		.map((pr) => {
 			return `- Title: ${pr.title}, Merged: ${pr.merged ? "Yes" : "No"}, URL: ${pr.url}`;
+		})
+		.join("\n");
+};
+
+export const formatTaskList = (tasks: Task[]) => {
+	return tasks
+		.map((task) => {
+			return `${task.complete ? "[X]" : "[ ]"} ${task.description}`;
 		})
 		.join("\n");
 };


### PR DESCRIPTION
This PR adds task information for a story. This is helpful in an MCP setting as it helps describe to the LLM how to break down a story into steps, which the user can then prompt the LLM to take on one at a time.