### PR TITLE
Feature: Add new story tool to add comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@shortcut/mcp",
-	"version": "0.1.5",
+	"version": "0.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shortcut/mcp",
-			"version": "0.1.5",
+			"version": "0.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.6.1",

--- a/src/client/shortcut.ts
+++ b/src/client/shortcut.ts
@@ -1,8 +1,10 @@
 import type {
 	ShortcutClient as BaseClient,
+	CreateStoryComment,
 	CreateStoryParams,
 	Member,
 	MemberInfo,
+	StoryComment,
 	UpdateStory,
 	Workflow,
 } from "@shortcut/client";
@@ -219,5 +221,38 @@ export class ShortcutClientWrapper {
 		if (!stories) return { stories: null, total: null };
 
 		return { stories, total: stories.length };
+	}
+
+	/**
+	 * Create story comment using public ID.
+	 *
+	 * @param storyPublicId - The public ID of the story to comment on.
+	 * @param comment - The comment to add to the story.
+	 * @param authorId - The ID of the author of the comment. If not, the current user will be used from SHORTCUT_API_TOKEN.
+	 *
+	 * @returns {Promise<StoryComment>} The created story comment.
+	 */
+	async createStoryComment(
+		storyPublicId: number,
+		comment: string,
+		authorId?: string,
+	): Promise<StoryComment> {
+		const createStoryCommentParams = {
+			text: comment,
+		} as CreateStoryComment;
+
+		if (authorId) {
+			const author = await this.getUser(authorId);
+			if (!author) throw new Error(`User with ID ${authorId} not found`);
+
+			createStoryCommentParams.author_id = author.id;
+		}
+
+		const response = await this.client.createStoryComment(storyPublicId, createStoryCommentParams);
+		const storyComment = response?.data ?? null;
+
+		if (!storyComment) throw new Error(`Failed to create the comment: ${response.status}`);
+
+		return storyComment;
 	}
 }


### PR DESCRIPTION
This PR adds a new tool `create-story-comment` to allow users to add comments to stories.

## Implementation
- Added new tool `create-story-comment` in `stories.ts`.
- Implemented the `createStoryComment` method to add comments to a story (`author_id` defaults to the user identified by the API token if not provided).
- Added new method is `ShortcutClientWrapper` class to create story comment.
- Added test cases to validate the functionality.

## Test Cases Status
  - Passed - https://d.pr/i/wsVadH
  
I have tested the tool in my Windsurf IDE, and it is working as expected.