### PR TITLE
Feature - Create Epic + Create Iteration Tool

### DIFF
--- a/src/client/shortcut.ts
+++ b/src/client/shortcut.ts
@@ -284,13 +284,13 @@ export class ShortcutClientWrapper {
 		name: string,
 		description?: string,
 	): Promise<Iteration> {
-		const createIterationParams = {
+		const createIterationParams: CreateIteration = {
 			name,
 			description,
 			start_date: startDate,
 			end_date: endDate,
 			group_ids: [groupId],
-		} as CreateIteration;
+		};
 
 		const response = await this.client.createIteration(createIterationParams);
 		const iteration = response?.data ?? null;
@@ -308,11 +308,11 @@ export class ShortcutClientWrapper {
 	 * @param description - The description of the epic.
 	 */
 	async createEpic(groupId: string, name: string, description?: string): Promise<Epic> {
-		const createEpicParams = {
+		const createEpicParams: CreateEpic = {
 			name,
 			description,
 			group_id: groupId,
-		} as CreateEpic;
+		};
 
 		const response = await this.client.createEpic(createEpicParams);
 		const epic = response?.data ?? null;

--- a/src/client/shortcut.ts
+++ b/src/client/shortcut.ts
@@ -1,7 +1,11 @@
 import type {
 	ShortcutClient as BaseClient,
+	CreateEpic,
+	CreateIteration,
 	CreateStoryComment,
 	CreateStoryParams,
+	Epic,
+	Iteration,
 	Member,
 	MemberInfo,
 	StoryComment,
@@ -262,5 +266,59 @@ export class ShortcutClientWrapper {
 		if (!storyComment) throw new Error(`Failed to create the comment: ${response.status}`);
 
 		return storyComment;
+	}
+
+	/**
+	 * Create iteration
+	 *
+	 * @param groupId - The ID of the group to assign the iteration to. Group means team in Shortcut.
+	 * @param startDate - The start date of the iteration in ISO 8601 format.
+	 * @param endDate - The end date of the iteration in ISO 8601 format.
+	 * @param name - The name of the iteration.
+	 * @param description - The description of the iteration.
+	 */
+	async createIteration(
+		groupId: string,
+		startDate: string,
+		endDate: string,
+		name: string,
+		description?: string,
+	): Promise<Iteration> {
+		const createIterationParams = {
+			name,
+			description,
+			start_date: startDate,
+			end_date: endDate,
+			group_ids: [groupId],
+		} as CreateIteration;
+
+		const response = await this.client.createIteration(createIterationParams);
+		const iteration = response?.data ?? null;
+
+		if (!iteration) throw new Error(`Failed to create the iteration: ${response.status}`);
+
+		return iteration;
+	}
+
+	/**
+	 * Create epic
+	 *
+	 * @param groupId - The ID of the group to assign the epic to. Group means team in Shortcut.
+	 * @param name - The name of the epic.
+	 * @param description - The description of the epic.
+	 */
+	async createEpic(groupId: string, name: string, description?: string): Promise<Epic> {
+		const createEpicParams = {
+			name,
+			description,
+			group_id: groupId,
+		} as CreateEpic;
+
+		const response = await this.client.createEpic(createEpicParams);
+		const epic = response?.data ?? null;
+
+		if (!epic) throw new Error(`Failed to create the epic: ${response.status}`);
+
+		return epic;
 	}
 }

--- a/src/tools/epics.ts
+++ b/src/tools/epics.ts
@@ -1,5 +1,6 @@
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { BaseTools } from "./base";
 import { formatAsUnorderedList, formatStats } from "./utils/format";
@@ -61,6 +62,17 @@ export class EpicTools extends BaseTools {
 			async (params) => await tools.searchEpics(params),
 		);
 
+		server.tool(
+			"create-epic",
+			"Create a new Shortcut epic.",
+			{
+				groupId: z.string().describe("The ID of the group or team to assign the epic to"),
+				name: z.string().describe("The name of the epic"),
+				description: z.string().optional().describe("The description of the epic"),
+			},
+			async ({ groupId, name, description }) => await tools.createEpic(groupId, name, description),
+		);
+
 		return tools;
 	}
 
@@ -98,5 +110,30 @@ ${formatStats(epic.stats, showPoints)}
 
 Description:
 ${epic.description}`);
+	}
+
+	/**
+	 * Create a new Shortcut epic.
+	 *
+	 * @param groupId - The ID of the group or team to assign the epic to.
+	 * @param name - The name of the epic.
+	 * @param description - The description of the epic.
+	 *
+	 * @returns The created epic.
+	 */
+	async createEpic(groupId: string, name: string, description?: string): Promise<CallToolResult> {
+		if (!groupId) {
+			throw new Error("Group ID is required to create an epic.");
+		}
+
+		const group = await this.client.getTeam(groupId);
+		if (!group) throw new Error(`Group with ID ${groupId} not found`);
+
+		const epic = await this.client.createEpic(group.id, name, description);
+
+		return this.toResult(`Epic created: ${epic.id}
+URL: ${epic.app_url}
+Name: ${epic.name}
+Description: ${epic.description}`);
 	}
 }

--- a/src/tools/epics.ts
+++ b/src/tools/epics.ts
@@ -66,11 +66,11 @@ export class EpicTools extends BaseTools {
 			"create-epic",
 			"Create a new Shortcut epic.",
 			{
-				groupId: z.string().describe("The ID of the group or team to assign the epic to"),
+				teamId: z.string().describe("The ID of the team to assign the epic to"),
 				name: z.string().describe("The name of the epic"),
 				description: z.string().optional().describe("The description of the epic"),
 			},
-			async ({ groupId, name, description }) => await tools.createEpic(groupId, name, description),
+			async ({ teamId, name, description }) => await tools.createEpic(teamId, name, description),
 		);
 
 		return tools;

--- a/src/tools/iterations.ts
+++ b/src/tools/iterations.ts
@@ -63,10 +63,10 @@ export class IterationTools extends BaseTools {
 				description: z.string().optional().describe("The description of the iteration"),
 				startDate: z.string().describe("The start date of the iteration"),
 				endDate: z.string().describe("The end date of the iteration"),
-				groupId: z.string().describe("The ID of the group to assign the iteration to"),
+				teamId: z.string().describe("The ID of the team to assign the iteration to"),
 			},
-			async ({ name, description, startDate, endDate, groupId }) => {
-				return await tools.createIteration(groupId, startDate, endDate, name, description);
+			async ({ name, description, startDate, endDate, teamId }) => {
+				return await tools.createIteration(teamId, startDate, endDate, name, description);
 			},
 		);
 

--- a/src/tools/iterations.ts
+++ b/src/tools/iterations.ts
@@ -1,5 +1,6 @@
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { BaseTools } from "./base";
 import { formatAsUnorderedList, formatStats, formatStoryList } from "./utils/format";
@@ -52,6 +53,21 @@ export class IterationTools extends BaseTools {
 				endDate: date,
 			},
 			async (params) => await tools.searchIterations(params),
+		);
+
+		server.tool(
+			"create-iteration",
+			"Create a new Shortcut iteration",
+			{
+				name: z.string().describe("The name of the iteration"),
+				description: z.string().optional().describe("The description of the iteration"),
+				startDate: z.string().describe("The start date of the iteration"),
+				endDate: z.string().describe("The end date of the iteration"),
+				groupId: z.string().describe("The ID of the group to assign the iteration to"),
+			},
+			async ({ name, description, startDate, endDate, groupId }) => {
+				return await tools.createIteration(groupId, startDate, endDate, name, description);
+			},
 		);
 
 		return tools;
@@ -108,5 +124,48 @@ ${formatStats(iteration.stats, showPoints)}
 
 Description:
 ${iteration.description}`);
+	}
+
+	/**
+	 * Create a new Shortcut iteration.
+	 *
+	 * @param groupId - The ID of the group to assign the iteration to.
+	 * @param startDate - The start date of the iteration.
+	 * @param endDate - The end date of the iteration.
+	 * @param name - The name of the iteration.
+	 * @param description - The description of the iteration.
+	 *
+	 * @returns The result of the iteration creation.
+	 */
+	async createIteration(
+		groupId: string,
+		startDate: string,
+		endDate: string,
+		name: string,
+		description?: string,
+	): Promise<CallToolResult> {
+		if (!groupId) {
+			throw new Error("Group ID is required to create an iteration.");
+		}
+
+		const group = await this.client.getTeam(groupId);
+		if (!group) throw new Error(`Group with ID ${groupId} not found`);
+
+		const iteration = await this.client.createIteration(
+			group.id,
+			startDate,
+			endDate,
+			name,
+			description,
+		);
+
+		if (!iteration) throw new Error(`Failed to create the iteration.`);
+
+		return this.toResult(`Iteration created successfully:
+Iteration ID: ${iteration.id}
+Iteration URL: ${iteration.app_url}
+Iteration Name: ${iteration.name}
+Iteration Start Date: ${iteration.start_date}
+Iteration End Date: ${iteration.end_date}`);
 	}
 }


### PR DESCRIPTION
This PR adds a new tool `create-epic` and `create-iteration` to allow LLMs to create epic and iteration in Shortcut.

## Implementation
- Added `create-epic` tool in epics.ts.
- Added `create-iteration` tool in iterations.ts.
- Implemented `createEpic` and `createIteration` methods.
- Extended the `ShortcutClientWrapper` class with support for creating epics and iterations.
- Added corresponding test cases to ensure functionality.
- Added mockTeam setup in `iterations.test.ts` and `epic.test.test` to create mock client.

## Testing
  - All test cases have passed - https://d.pr/i/yUlv7i
  - Verified functionality locally in VS Code.
