### PR TITLE
Feature - Add + Update Story Task (with owners) Tool | Add Story Relationships Tool

### DIFF
--- a/src/tools/stories.ts
+++ b/src/tools/stories.ts
@@ -227,6 +227,45 @@ The story will be added to the default state for the workflow.
 			async (params) => await tools.createStoryComment(params),
 		);
 
+		server.tool(
+			"add-task-to-story",
+			"Add a task to a story",
+			{
+				storyPublicId: z.number().positive().describe("The public ID of the story"),
+				taskDescription: z.string().min(1).describe("The description of the task"),
+				taskOwnerIds: z
+					.array(z.string())
+					.optional()
+					.describe("Array of user IDs to assign as owners of the task"),
+			},
+			async (params) => await tools.addTaskToStory(params),
+		);
+
+		server.tool(
+			"add-relation-to-story",
+			"Add a relation to a story",
+			{
+				storyPublicId: z.number().positive().describe("The public ID of the story"),
+				relatedStoryPublicId: z.number().positive().describe("The public ID of the related story"),
+			},
+			async (params) => await tools.addRelationToStory(params),
+		);
+
+		server.tool(
+			"update-task",
+			"Update a task in a story",
+			{
+				storyPublicId: z.number().positive().describe("The public ID of the story"),
+				taskPublicId: z.number().positive().describe("The public ID of the task"),
+				taskDescription: z.string().optional().describe("The description of the task"),
+				taskOwnerIds: z
+					.array(z.string())
+					.optional()
+					.describe("Array of user IDs to assign as owners of the task"),
+			},
+			async (params) => await tools.updateTask(params),
+		);
+
 		return tools;
 	}
 
@@ -462,5 +501,89 @@ ${(story.comments || [])
 		const updatedStory = await this.client.updateStory(storyPublicId, updateParams);
 
 		return this.toResult(`Updated story sc-${storyPublicId}. Story URL: ${updatedStory.app_url}`);
+	}
+
+	async addTaskToStory({
+		storyPublicId,
+		taskDescription,
+		taskOwnerIds,
+	}: {
+		storyPublicId: number;
+		taskDescription: string;
+		taskOwnerIds?: string[];
+	}) {
+		if (!storyPublicId) throw new Error("Story public ID is required");
+		if (!taskDescription) throw new Error("Task description is required");
+
+		const story = await this.client.getStory(storyPublicId);
+		if (!story)
+			throw new Error(`Failed to retrieve Shortcut story with public ID: ${storyPublicId}`);
+
+		if (taskOwnerIds?.length) {
+			const owners = await this.client.getUserMap(taskOwnerIds as string[]);
+			console.log(owners);
+			if (!owners) throw new Error(`Failed to retrieve users with IDs: ${taskOwnerIds.join(", ")}`);
+		}
+
+		const task = await this.client.addTaskToStory(storyPublicId, {
+			description: taskDescription,
+			ownerIds: taskOwnerIds,
+		});
+
+		return this.toResult(`Created task for story sc-${storyPublicId}. Task ID: ${task.id}.`);
+	}
+
+	async updateTask({
+		storyPublicId,
+		taskPublicId,
+		taskDescription,
+		taskOwnerIds,
+	}: {
+		storyPublicId: number;
+		taskPublicId: number;
+		taskDescription?: string;
+		taskOwnerIds?: string[];
+	}) {
+		if (!storyPublicId) throw new Error("Story public ID is required");
+		if (!taskPublicId) throw new Error("Task public ID is required");
+
+		const story = await this.client.getStory(storyPublicId);
+		if (!story)
+			throw new Error(`Failed to retrieve Shortcut story with public ID: ${storyPublicId}`);
+
+		const task = await this.client.getTask(storyPublicId, taskPublicId);
+		if (!task) throw new Error(`Failed to retrieve Shortcut task with public ID: ${taskPublicId}`);
+
+		const updatedTask = await this.client.updateTask(storyPublicId, taskPublicId, {
+			description: taskDescription,
+			ownerIds: taskOwnerIds,
+		});
+
+		return this.toResult(`Updated task for story sc-${storyPublicId}. Task ID: ${updatedTask.id}.`);
+	}
+
+	async addRelationToStory({
+		storyPublicId,
+		relatedStoryPublicId,
+	}: {
+		storyPublicId: number;
+		relatedStoryPublicId: number;
+	}) {
+		if (!storyPublicId) throw new Error("Story public ID is required");
+		if (!relatedStoryPublicId) throw new Error("Related story public ID is required");
+
+		const story = await this.client.getStory(storyPublicId);
+		if (!story)
+			throw new Error(`Failed to retrieve Shortcut story with public ID: ${storyPublicId}`);
+
+		const relatedStory = await this.client.getStory(relatedStoryPublicId);
+		if (!relatedStory)
+			throw new Error(`Failed to retrieve Shortcut story with public ID: ${relatedStoryPublicId}`);
+
+		await this.client.addRelationToStory(storyPublicId, relatedStoryPublicId);
+
+		return this.toResult(
+			`Added relation between stories sc-${storyPublicId} and sc-${relatedStoryPublicId}.`,
+		);
 	}
 }

--- a/src/tools/user.test.ts
+++ b/src/tools/user.test.ts
@@ -18,8 +18,9 @@ describe("UserTools", () => {
 
 			UserTools.create(mockClient, mockServer);
 
-			expect(mockTool).toHaveBeenCalledTimes(1);
+			expect(mockTool).toHaveBeenCalledTimes(2);
 			expect(mockTool.mock.calls?.[0]?.[0]).toBe("get-current-user");
+			expect(mockTool.mock.calls?.[1]?.[0]).toBe("list-members");
 		});
 
 		test("should call correct function from tool", async () => {
@@ -70,6 +71,37 @@ describe("UserTools", () => {
 			} as unknown as ShortcutClientWrapper);
 
 			await expect(() => userTools.getCurrentUser()).toThrow("API error");
+		});
+	});
+
+	describe("listMembers method", () => {
+		const mockMembers = [
+			{ id: "user1", name: "User One", profile: { mention_name: "user1" } },
+			{ id: "user2", name: "User Two", profile: { mention_name: "user2" } },
+		];
+
+		const listMembersMock = mock(async () => mockMembers);
+		const mockClient = { listMembers: listMembersMock } as unknown as ShortcutClientWrapper;
+
+		test("should return formatted list of members", async () => {
+			const userTools = new UserTools(mockClient);
+			const result = await userTools.listMembers();
+
+			console.log(JSON.stringify(result.content, null, 2));
+			expect(result.content[0].type).toBe("text");
+			expect(String(result.content[0].text)).toContain("Found 2 members,");
+			expect(String(result.content[0].text)).toContain("@user1");
+			expect(String(result.content[0].text)).toContain("@user2");
+		});
+
+		test("should propagate errors from client", async () => {
+			const userTools = new UserTools({
+				listMembers: mock(async () => {
+					throw new Error("API error");
+				}),
+			} as unknown as ShortcutClientWrapper);
+
+			await expect(() => userTools.listMembers()).toThrow("API error");
 		});
 	});
 });

--- a/src/tools/user.ts
+++ b/src/tools/user.ts
@@ -1,6 +1,7 @@
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { BaseTools } from "./base";
+import { formatUsersList } from "./utils/format";
 
 export class UserTools extends BaseTools {
 	static create(client: ShortcutClientWrapper, server: McpServer) {
@@ -11,6 +12,8 @@ export class UserTools extends BaseTools {
 			"Get the current user",
 			async () => await tools.getCurrentUser(),
 		);
+
+		server.tool("list-members", "Get all members", async () => await tools.listMembers());
 
 		return tools;
 	}
@@ -26,5 +29,11 @@ Id: ${user.id}
 Mention name: @${user.mention_name}
 Full name: ${user.name}`,
 		);
+	}
+
+	async listMembers() {
+		const members = await this.client.listMembers();
+
+		return this.toResult(`Found ${members.length} members, ${formatUsersList(members)}`);
 	}
 }

--- a/src/tools/utils/format.ts
+++ b/src/tools/utils/format.ts
@@ -211,3 +211,7 @@ export const formatStats = (stats: EpicStats | IterationStats, showPoints: boole
 
 	return statsString;
 };
+
+export const formatUsersList = (users: Member[]) => {
+	return formatAsUnorderedList(users.map((user) => `id=${user.id} @${user.profile.mention_name}`));
+};

--- a/src/tools/utils/format.ts
+++ b/src/tools/utils/format.ts
@@ -213,5 +213,10 @@ export const formatStats = (stats: EpicStats | IterationStats, showPoints: boole
 };
 
 export const formatUsersList = (users: Member[]) => {
-	return formatAsUnorderedList(users.map((user) => `id=${user.id} @${user.profile.mention_name}`));
+	return formatAsUnorderedList(
+		users.map(
+			(user) =>
+				`id=${user.id} ${user?.profile?.mention_name ? `@${user.profile.mention_name}` : ""} : ""}`,
+		),
+	);
 };


### PR DESCRIPTION
## Implementation
- Add tool `add-task-to-story` to add tasks to story with owners as optional.
   - Extended the ShortcutClientWrapper class with support for adding tasks to a story.
- Add tool `update-task` to update task description and owners.
   - Extended the ShortcutClientWrapper class with support for updating task.
- Add tool `add-relation-to-story` to add story relationships.
   - Extended the ShortcutClientWrapper class with support for creating story relationships.
- Add tool l`ist-members` to list all members of the workspace.
- Added relevant test cases in `stories.test.ts` and `user.test.ts`.

## Testing
  - All test cases have passed - https://d.pr/i/1Qw9sa
  - Verified functionality locally in VS Code.
