### PR TITLE
Fix search by team

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"modelcontextprotocol"
 	],
 	"license": "MIT",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"type": "module",
 	"main": "dist/index.js",
 	"bin": {

--- a/src/tools/epics.test.ts
+++ b/src/tools/epics.test.ts
@@ -279,7 +279,7 @@ describe("EpicTools", () => {
 			});
 
 			expect(searchEpicsMock.mock.calls?.[0]?.[0]).toBe(
-				'id:1 title:"Test Epic" description:"Test Description" state:started objective:123 owner:testuser group:engineering is:archived',
+				'id:1 title:"Test Epic" description:"Test Description" state:started objective:123 owner:testuser team:engineering is:archived',
 			);
 		});
 

--- a/src/tools/utils/search.ts
+++ b/src/tools/utils/search.ts
@@ -1,6 +1,6 @@
 import type { MemberInfo } from "@shortcut/client";
 
-const keyRenames = { team: "group", name: "title" } as const;
+const keyRenames = { name: "title" } as const;
 
 const mapKeyName = (key: string) => {
 	const lowercaseKey = key.toLowerCase();


### PR DESCRIPTION
The team parameter should be called `team`, not `group`.