### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # @shortcut/mcp
 
+A dynamic MCP server management service that creates, runs, and manages Model Context Protocol (MCP) servers dynamically. This service itself functions as an MCP server and launches/manages other MCP servers as child processes, enabling a flexible MCP ecosystem.
+
+<a href="https://glama.ai/mcp/servers/@useshortcut/mcp-server-shortcut">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@useshortcut/mcp-server-shortcut/badge" alt="Shortcut Server MCP server" />
+</a>
+
 ## Usage
 
 ### Windsurf


### PR DESCRIPTION
This PR adds a badge for the [Shortcut MCP Server](https://glama.ai/mcp/servers/@useshortcut/mcp-server-shortcut) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@useshortcut/mcp-server-shortcut">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@useshortcut/mcp-server-shortcut/badge" alt="Shortcut Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.