### PR TITLE
Add get-story-summary and get-story-tasks tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@shortcut/mcp",
-	"version": "0.8.4",
+	"version": "0.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shortcut/mcp",
-			"version": "0.8.4",
+			"version": "0.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.11.3",

--- a/src/client/shortcut.ts
+++ b/src/client/shortcut.ts
@@ -342,6 +342,18 @@ export class ShortcutClientWrapper {
 		return storyComment;
 	}
 
+	async getStoryComment(
+		storyPublicId: number,
+		commentPublicId: number,
+	): Promise<StoryComment | null> {
+		const response = await this.client.getStoryComment(storyPublicId, commentPublicId);
+		const storyComment = response?.data ?? null;
+
+		if (!storyComment) return null;
+
+		return storyComment;
+	}
+
 	async createIteration(params: CreateIteration): Promise<Iteration> {
 		const response = await this.client.createIteration(params);
 		const iteration = response?.data ?? null;

--- a/src/tools/stories.test.ts
+++ b/src/tools/stories.test.ts
@@ -149,7 +149,7 @@ describe("StoryTools", () => {
 
 			StoryTools.create(mockClient, mockServer);
 
-			expect(mockTool).toHaveBeenCalledTimes(15);
+			expect(mockTool).toHaveBeenCalledTimes(17);
 			expect(mockTool.mock.calls?.[0]?.[0]).toBe("get-story-branch-name");
 			expect(mockTool.mock.calls?.[1]?.[0]).toBe("get-story");
 			expect(mockTool.mock.calls?.[2]?.[0]).toBe("search-stories");
@@ -161,6 +161,12 @@ describe("StoryTools", () => {
 			expect(mockTool.mock.calls?.[8]?.[0]).toBe("add-task-to-story");
 			expect(mockTool.mock.calls?.[9]?.[0]).toBe("add-relation-to-story");
 			expect(mockTool.mock.calls?.[10]?.[0]).toBe("update-task");
+			expect(mockTool.mock.calls?.[11]?.[0]).toBe("add-external-link-to-story");
+			expect(mockTool.mock.calls?.[12]?.[0]).toBe("remove-external-link-from-story");
+			expect(mockTool.mock.calls?.[13]?.[0]).toBe("get-stories-by-external-link");
+			expect(mockTool.mock.calls?.[14]?.[0]).toBe("set-story-external-links");
+			expect(mockTool.mock.calls?.[15]?.[0]).toBe("get-story-summary");
+			expect(mockTool.mock.calls?.[16]?.[0]).toBe("get-story-tasks");
 		});
 	});
 

--- a/src/tools/stories.ts
+++ b/src/tools/stories.ts
@@ -698,11 +698,26 @@ The story will be added to the default state for the workflow.
 		if (!story)
 			throw new Error(`Failed to retrieve Shortcut story with public ID: ${storyPublicId}`);
 
+		// Get requester info if available
+		let requesterInfo = null;
+		if (story.requested_by_id) {
+			const requester = await this.client.getUser(story.requested_by_id);
+			if (requester) {
+				requesterInfo = {
+					id: requester.id,
+					name: requester.profile?.name || requester.profile?.mention_name || "Unknown",
+				};
+			}
+		}
+
 		return this.toResult(`Story summary for sc-${storyPublicId}`, {
 			id: story.id,
 			name: story.name,
 			description: story.description || "No description",
 			app_url: story.app_url,
+			epic_id: story.epic_id || null,
+			requester_id: story.requested_by_id || null,
+			requester_name: requesterInfo?.name || null,
 		});
 	}
 

--- a/src/tools/stories.ts
+++ b/src/tools/stories.ts
@@ -337,6 +337,17 @@ The story will be added to the default state for the workflow.
 			async ({ storyPublicId }) => await tools.getStoryTasks(storyPublicId),
 		);
 
+		server.tool(
+			"get-story-comment",
+			"Get a specific story comment by activity ID",
+			{
+				storyPublicId: z.number().positive().describe("The public ID of the story"),
+				activityId: z.number().positive().describe("The activity ID of the comment"),
+			},
+			async ({ storyPublicId, activityId }) =>
+				await tools.getStoryComment(storyPublicId, activityId),
+		);
+
 		return tools;
 	}
 
@@ -744,6 +755,32 @@ The story will be added to the default state for the workflow.
 				created_at: task.created_at,
 				updated_at: task.updated_at,
 			})),
+		});
+	}
+
+	async getStoryComment(storyPublicId: number, activityId: number) {
+		const comment = await this.client.getStoryComment(storyPublicId, activityId);
+
+		if (!comment) {
+			throw new Error(
+				`Failed to retrieve comment with activity ID ${activityId} for story sc-${storyPublicId}`,
+			);
+		}
+
+		return this.toResult(`Story comment for sc-${storyPublicId}`, {
+			id: comment.id,
+			story_id: comment.story_id,
+			text: comment.text,
+			author_id: comment.author_id,
+			created_at: comment.created_at,
+			updated_at: comment.updated_at,
+			app_url: comment.app_url,
+			deleted: comment.deleted,
+			blocker: comment.blocker,
+			parent_id: comment.parent_id,
+			position: comment.position,
+			member_mention_ids: comment.member_mention_ids,
+			group_mention_ids: comment.group_mention_ids,
 		});
 	}
 }


### PR DESCRIPTION
## Summary
  This PR adds two new tools to the MCP server for more efficient story data retrieval:
  - `get-story-summary`: Returns only the title and description of a story
  - `get-story-tasks`: Returns all tasks (subtasks) for a story

  ## Motivation
  These tools provide more focused data retrieval options when you only need specific story information, avoiding the need to fetch the full story object when you just need the summary or tasks. Essential when trying to save model context.

  ## Changes
  - Added `get-story-summary` tool that returns `id`, `name`, `description`, and `app_url`
  - Added `get-story-tasks` tool that returns all tasks with their details (`id`, `description`, `complete`, `owner_ids`, `created_at`, `updated_at`)
  - Both tools reuse the existing `getStory()` API call for efficiency
  - Updated tests to reflect the new tool count (from 15 to 17)

  ## Testing
  - All existing tests pass
  - Updated `StoryTools` test to expect 17 tools instead of 15
  - Both new methods follow the existing error handling patterns

  ## Example Usage
  ```typescript
  // Get just the story summary
  await tools.getStorySummary(12345);

  // Get all tasks for a story
  await tools.getStoryTasks(12345);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added ability to retrieve story summaries including description and requester information
* Added ability to fetch and view story tasks with completion status and ownership details
* Added ability to retrieve individual story comments with full metadata, including mentions and blocker flags

## Tests
* Expanded test coverage for story summary, task, and comment retrieval functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->