### PR TITLE
Migrate from `bun` to `tsdown` to achieve a smaller footprint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@shortcut/mcp",
-	"version": "0.8.4",
+	"version": "0.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shortcut/mcp",
-			"version": "0.8.4",
+			"version": "0.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.11.3",
@@ -21,10 +21,77 @@
 				"@types/bun": "latest",
 				"bun": "^1.2.5",
 				"husky": "^9.1.7",
-				"shx": "^0.3.4"
+				"tsdown": "^0.12.9"
 			},
 			"peerDependencies": {
 				"typescript": "^5"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+			"integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.28.0",
+				"@babel/types": "^7.28.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+			"integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.28.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.28.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+			"integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -190,6 +257,79 @@
 				"node": ">=14.21.3"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.4.tgz",
+			"integrity": "sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.0.3",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.4.tgz",
+			"integrity": "sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.3.tgz",
+			"integrity": "sha512-8K5IFFsQqF9wQNJptGbS6FNKgUTsSRYnTqNCG1vPP8jFdjSv18n2mQfJpkt2Oibo9iBEzcDnDxNwKTzC7svlJw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+			"integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+			"integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.29",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+			"integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
 		"node_modules/@modelcontextprotocol/sdk": {
 			"version": "1.11.3",
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.3.tgz",
@@ -209,6 +349,19 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.0.tgz",
+			"integrity": "sha512-OInwPIZhcQ+aWOBFMUXzv95RLDTBRPaNPm5kSFJaL3gVAMVxrzc0YXNsVeLPHf+4sTviOy2e5wZdvKILb7dC/w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.4.3",
+				"@emnapi/runtime": "^1.4.3",
+				"@tybys/wasm-util": "^0.10.0"
 			}
 		},
 		"node_modules/@oven/bun-darwin-aarch64": {
@@ -365,6 +518,248 @@
 				"win32"
 			]
 		},
+		"node_modules/@oxc-project/runtime": {
+			"version": "0.77.2",
+			"resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.77.2.tgz",
+			"integrity": "sha512-oqzN82vVbqK6BnUuYDlBMlMr8mEeysMn/P8HbiB3j5rD04JvIfONCfh6SbtJTxhp1C4cjLi1evrtVTIptrln7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.77.2",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.77.2.tgz",
+			"integrity": "sha512-+ZFWJF8ZBTOIO5PiNohNIw7JBzJCybScfrhLh65tcHCAtqaQkVDonjRD1HmMV/RF3rtt3r88hzSyTqvXs4j7vw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@quansync/fs": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-0.1.3.tgz",
+			"integrity": "sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"quansync": "^0.2.10"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sxzz"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.28.tgz",
+			"integrity": "sha512-hLb7k11KBXtO8xc7DO1OWriXWM/2FKv/R510NChqpzoI6au2aJbGUQTKJw4D8Mj7oHfY2Nwzy+sJBgWx/P8IKw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.28.tgz",
+			"integrity": "sha512-yRhjS3dcjfAasnJ2pTyCVm5rtfOmkGIglrFh+n9J7Zi4owJFsVVpbY7dOE3T1Op3mQ94apGN+Twtv6CIk6GFIQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.28.tgz",
+			"integrity": "sha512-eOX0pjz++yVdqcDqnoZeVXUHxak2AcEgQBlEKJYaeJj+O5V3r3wSnlDVSkgD6YEAHo2IlIa89+qFHv529esY6w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.28.tgz",
+			"integrity": "sha512-WV1QYVMkkp/568iaEBoZhD1axFLhSO+ybCJlbmHkTFMub4wb5bmKtfuaBgjUVDDSB6JfZ6UL3Z0Q9VVHENOgsg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.28.tgz",
+			"integrity": "sha512-ug/Wh9Tz4XB/CsYvaI2r5uC3vE3zrP5iDIsD+uEgFPV71BOQOfXFgZbC1zv+J1adkzWACr578aGQqW9jRj0gVA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.28.tgz",
+			"integrity": "sha512-h3hzQuP+5l47wxn9+A39n1Q3i4mAvbNFJCZ8EZLrkqfsecfeZ5btIbDJTVAIQTy+uPr7uluAHIf11Jw+YkWjOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.28.tgz",
+			"integrity": "sha512-oW5LydGtfdT8TI5HTybxi1DdMCXCmVE1ak4VrSmVKsbBZyE0bDgL1UvTS1OOvuq4PM24zQHIuSNOpgLXgVj4vQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rolldown/binding-linux-arm64-ohos": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-ohos/-/binding-linux-arm64-ohos-1.0.0-beta.28.tgz",
+			"integrity": "sha512-yeAAPMgssEkTCouUSYLrSWm+EXYBFI+ZTe8BVQkY5le51OCbqFNibtYkKZNHZBdhNRjWcSKSIuXN4MAXBz1j+g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.28.tgz",
+			"integrity": "sha512-xWsylmva9L4ZFc28A9VGlF9fnrFpVxVC+kKqrBoqz2l/p5b4zRoFNtnSecivnxuPeR5Ga6W6lnpwGeWDvqBZ1Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.28.tgz",
+			"integrity": "sha512-IdtRNm70EH7/1mjqXJc4pa2MoAxo/xl9hN8VySG9BQuYfhQz+JDC+FZBc+krlVUO3cTJz/o4xI/x4kA+rLKTwA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.28.tgz",
+			"integrity": "sha512-jS2G0+GtUCVcglCefScxgXeLJal0UAvVwvpy3reoC07K16k8WM/lXoYsZdpw34d5ONg0XcZpcokzA9R5K2o0lQ==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.28.tgz",
+			"integrity": "sha512-K6SO4e48aqpE/E6iEaXYG1kVX3owLierZUngP44f7s6WcnNUXsX8aborZZkKDKjgfk654M/EjSI7riPQXfynIA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rolldown/binding-win32-ia32-msvc": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.28.tgz",
+			"integrity": "sha512-IIAecHvlUY/oxADfA6sZFfmRx0ajY+U1rAPFT77COp11kf7irUJeD9GskFzCm+7Wm+q8Vogyh0KWqqd6f5Azgg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.28.tgz",
+			"integrity": "sha512-eMGdPBhNkylib+7eaeC69axEjg5Y1Vie5LoKDBVaZ71jYTmtrUdna9PTUblkCIChNTQKlgxpi/eCaYmhId0aYA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.28.tgz",
+			"integrity": "sha512-fe3/1HZ3qJmXvkGv1kacKq2b+x9gbcyF1hnmLBVrRFEQWoOcRapQjXf8+hgyxI0EJAbnKEtrp5yhohQCFCjycw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@shortcut/client": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@shortcut/client/-/client-1.1.0.tgz",
@@ -372,6 +767,17 @@
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.5.0"
+			}
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+			"integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@types/bun": {
@@ -415,6 +821,33 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/ansis": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansis/-/ansis-4.1.0.tgz",
+			"integrity": "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/ast-kit": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.1.tgz",
+			"integrity": "sha512-mfh6a7gKXE8pDlxTvqIc/syH/P3RkzbOF6LeHdcKztLEzYe6IMsRCL7N8vI7hqTGWNxpkCuuRTpT21xNWqhRtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.27.7",
+				"pathe": "^2.0.3"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sxzz"
+			}
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"license": "MIT"
@@ -430,10 +863,15 @@
 				"proxy-from-env": "^1.1.0"
 			}
 		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
+		"node_modules/birpc": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/birpc/-/birpc-2.5.0.tgz",
+			"integrity": "sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
 		},
 		"node_modules/body-parser": {
 			"version": "2.1.0",
@@ -495,15 +933,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/bun": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/bun/-/bun-1.2.5.tgz",
@@ -557,6 +986,16 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
 			"license": "MIT",
@@ -582,6 +1021,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"license": "MIT",
@@ -591,11 +1046,6 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.0",
@@ -668,6 +1118,13 @@
 				}
 			}
 		},
+		"node_modules/defu": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"license": "MIT",
@@ -690,6 +1147,37 @@
 				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
+		"node_modules/diff": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+			"integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/dts-resolver": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-2.1.1.tgz",
+			"integrity": "sha512-3BiGFhB6mj5Kv+W2vdJseQUYW+SKVzAFJL6YNP6ursbrwy1fXHRotfHi3xLNxe4wZl/K8qbAFeCDjZLjzqxxRw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sxzz"
+			},
+			"peerDependencies": {
+				"oxc-resolver": ">=11.0.0"
+			},
+			"peerDependenciesMeta": {
+				"oxc-resolver": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"license": "MIT",
@@ -705,6 +1193,16 @@
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"license": "MIT"
+		},
+		"node_modules/empathic": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+			"integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/encodeurl": {
 			"version": "2.0.0",
@@ -832,6 +1330,21 @@
 				"express": "^4.11 || 5 || ^5.0.0-beta.1"
 			}
 		},
+		"node_modules/fdir": {
+			"version": "6.4.6",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+			"integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/finalhandler": {
 			"version": "2.1.0",
 			"license": "MIT",
@@ -928,11 +1441,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
 			"license": "MIT",
@@ -973,23 +1481,17 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/glob": {
-			"version": "7.2.3",
+		"node_modules/get-tsconfig": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+			"integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
 			"dev": true,
-			"license": "ISC",
+			"license": "MIT",
 			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
+				"resolve-pkg-maps": "^1.0.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/gopd": {
@@ -1035,6 +1537,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hookable": {
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+			"integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/http-errors": {
 			"version": "2.0.0",
 			"license": "MIT",
@@ -1073,46 +1582,15 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"license": "ISC"
-		},
-		"node_modules/interpret": {
-			"version": "1.4.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
-			}
-		},
-		"node_modules/is-core-module": {
-			"version": "2.16.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-promise": {
@@ -1124,6 +1602,29 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
+		},
+		"node_modules/jiti": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+			"integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -1171,25 +1672,6 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/ms": {
@@ -1244,14 +1726,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1261,16 +1735,31 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/path-to-regexp": {
 			"version": "8.2.0",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/pkce-challenge": {
@@ -1310,6 +1799,23 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/quansync": {
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
+			"integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/antfu"
+				},
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/sxzz"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"license": "MIT",
@@ -1330,34 +1836,126 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/rechoir": {
-			"version": "0.6.2",
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
 			"dev": true,
-			"dependencies": {
-				"resolve": "^1.1.6"
-			},
+			"license": "MIT",
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
-		"node_modules/resolve": {
-			"version": "1.22.10",
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
+		"node_modules/rolldown": {
+			"version": "1.0.0-beta.28",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.28.tgz",
+			"integrity": "sha512-QOANlVluwwrLP5snQqKfC2lv/KJphMkjh4V0gpw0K40GdKmhd8eShIGOJNAC51idk5cn3xI08SZTRWj0R2XlDw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.16.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
+				"@oxc-project/runtime": "=0.77.2",
+				"@oxc-project/types": "=0.77.2",
+				"@rolldown/pluginutils": "1.0.0-beta.28",
+				"ansis": "^4.0.0"
 			},
 			"bin": {
-				"resolve": "bin/resolve"
+				"rolldown": "bin/cli.mjs"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.0.0-beta.28",
+				"@rolldown/binding-darwin-arm64": "1.0.0-beta.28",
+				"@rolldown/binding-darwin-x64": "1.0.0-beta.28",
+				"@rolldown/binding-freebsd-x64": "1.0.0-beta.28",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.28",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.28",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-beta.28",
+				"@rolldown/binding-linux-arm64-ohos": "1.0.0-beta.28",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-beta.28",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-beta.28",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-beta.28",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.28",
+				"@rolldown/binding-win32-ia32-msvc": "1.0.0-beta.28",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-beta.28"
+			}
+		},
+		"node_modules/rolldown-plugin-dts": {
+			"version": "0.13.14",
+			"resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.13.14.tgz",
+			"integrity": "sha512-wjNhHZz9dlN6PTIXyizB6u/mAg1wEFMW9yw7imEVe3CxHSRnNHVyycIX0yDEOVJfDNISLPbkCIPEpFpizy5+PQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/generator": "^7.28.0",
+				"@babel/parser": "^7.28.0",
+				"@babel/types": "^7.28.1",
+				"ast-kit": "^2.1.1",
+				"birpc": "^2.5.0",
+				"debug": "^4.4.1",
+				"dts-resolver": "^2.1.1",
+				"get-tsconfig": "^4.10.1"
 			},
 			"engines": {
-				"node": ">= 0.4"
+				"node": ">=20.18.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"url": "https://github.com/sponsors/sxzz"
+			},
+			"peerDependencies": {
+				"@typescript/native-preview": ">=7.0.0-dev.20250601.1",
+				"rolldown": "^1.0.0-beta.9",
+				"typescript": "^5.0.0",
+				"vue-tsc": "^2.2.0 || ^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@typescript/native-preview": {
+					"optional": true
+				},
+				"typescript": {
+					"optional": true
+				},
+				"vue-tsc": {
+					"optional": true
+				}
 			}
+		},
+		"node_modules/rolldown-plugin-dts/node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/rolldown-plugin-dts/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/router": {
 			"version": "2.1.0",
@@ -1392,6 +1990,19 @@
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"license": "MIT"
+		},
+		"node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/send": {
 			"version": "1.1.0",
@@ -1495,37 +2106,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/shelljs": {
-			"version": "0.8.5",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"glob": "^7.0.0",
-				"interpret": "^1.0.0",
-				"rechoir": "^0.6.2"
-			},
-			"bin": {
-				"shjs": "bin/shjs"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/shx": {
-			"version": "0.3.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.3",
-				"shelljs": "^0.8.5"
-			},
-			"bin": {
-				"shx": "lib/cli.js"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/side-channel": {
 			"version": "1.1.0",
 			"license": "MIT",
@@ -1597,15 +2177,28 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
+		"node_modules/tinyexec": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+			"integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.14",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+			"integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.4.4",
+				"picomatch": "^4.0.2"
+			},
 			"engines": {
-				"node": ">= 0.4"
+				"node": ">=12.0.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
 		"node_modules/toidentifier": {
@@ -1614,6 +2207,94 @@
 			"engines": {
 				"node": ">=0.6"
 			}
+		},
+		"node_modules/tsdown": {
+			"version": "0.12.9",
+			"resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.12.9.tgz",
+			"integrity": "sha512-MfrXm9PIlT3saovtWKf/gCJJ/NQCdE0SiREkdNC+9Qy6UHhdeDPxnkFaBD7xttVUmgp0yUHtGirpoLB+OVLuLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansis": "^4.1.0",
+				"cac": "^6.7.14",
+				"chokidar": "^4.0.3",
+				"debug": "^4.4.1",
+				"diff": "^8.0.2",
+				"empathic": "^2.0.0",
+				"hookable": "^5.5.3",
+				"rolldown": "^1.0.0-beta.19",
+				"rolldown-plugin-dts": "^0.13.12",
+				"semver": "^7.7.2",
+				"tinyexec": "^1.0.1",
+				"tinyglobby": "^0.2.14",
+				"unconfig": "^7.3.2"
+			},
+			"bin": {
+				"tsdown": "dist/run.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sxzz"
+			},
+			"peerDependencies": {
+				"@arethetypeswrong/core": "^0.18.1",
+				"publint": "^0.3.0",
+				"typescript": "^5.0.0",
+				"unplugin-lightningcss": "^0.4.0",
+				"unplugin-unused": "^0.5.0"
+			},
+			"peerDependenciesMeta": {
+				"@arethetypeswrong/core": {
+					"optional": true
+				},
+				"publint": {
+					"optional": true
+				},
+				"typescript": {
+					"optional": true
+				},
+				"unplugin-lightningcss": {
+					"optional": true
+				},
+				"unplugin-unused": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tsdown/node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tsdown/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD",
+			"optional": true
 		},
 		"node_modules/type-is": {
 			"version": "2.0.0",
@@ -1637,6 +2318,22 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/unconfig": {
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.3.2.tgz",
+			"integrity": "sha512-nqG5NNL2wFVGZ0NA/aCFw0oJ2pxSf1lwg4Z5ill8wd7K4KX/rQbHlwbh+bjctXL5Ly1xtzHenHGOK0b+lG6JVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@quansync/fs": "^0.1.1",
+				"defu": "^6.1.4",
+				"jiti": "^2.4.2",
+				"quansync": "^0.2.8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"@types/bun": "latest",
 		"bun": "^1.2.5",
 		"husky": "^9.1.7",
-		"shx": "^0.3.4"
+		"tsdown": "^0.12.9"
 	},
 	"peerDependencies": {
 		"typescript": "^5"
@@ -41,9 +41,8 @@
 		"format": "biome check --write ./",
 		"lint": "biome check ./",
 		"ts": "tsc -b",
-		"build": "bun build ./index.ts --outfile dist/index.js --target node",
+		"build": "tsdown",
 		"prepublish": "bun run build",
-		"postbuild": "shx chmod +x dist/*.js",
 		"prepare": "husky"
 	}
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: 'index.ts',
+  outDir: 'dist',
+  format: 'esm',
+  clean: true,
+});


### PR DESCRIPTION
I noticed [`@shortcut/mcp`](https://www.npmjs.com/package/@shortcut/mcp) has an unpacked size of 706 kB, which is significant and unexpected. This is caused by our bundler (Bun) bundling everything (dependencies) within the output file. 

Rather than doing this (unless we would like to use this MCP as a standalone binary), we can leverage our `package.json` and let consumers handle dependencies like a regular npm package. Bun offers the ability to configure this via [`--packages external`](https://bun.sh/docs/bundler#packages); unfortunately, it doesn't work with TypeScript's `paths`, such as `@/client`. See https://github.com/oven-sh/bun/issues/14721.

I migrated from `bun` to [`tsdown`](https://tsdown.dev/) and replicated the existing configuration, which reduced the package size from **706 kB** to **69.8 kB** 📦.