### PR TITLE
Implement Document creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.11.3",
-				"@shortcut/client": "^1.1.0",
+				"@shortcut/client": "^2.2.0",
 				"zod": "^3.24.4"
 			},
 			"bin": {
@@ -761,12 +761,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@shortcut/client": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@shortcut/client/-/client-1.1.0.tgz",
-			"integrity": "sha512-GLpfo4mQId4e32kju85v9HI7q2dVhiJnBcsnRH9IaZLd4JPgf9tETSOXFaQLzHC+pyY730ogsKDepU9yhkts2g==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@shortcut/client/-/client-2.2.0.tgz",
+			"integrity": "sha512-NzcZBkDkdE2lxPSYQEEHyG1kLjaj8wVFBoDFq1gShaKZTzU/5mHBEaB+4EBbA3lfZHR+ppkl3a1JmpU1BFGFdA==",
 			"license": "MIT",
 			"dependencies": {
-				"axios": "^1.5.0"
+				"axios": "^1.9.0"
 			}
 		},
 		"node_modules/@tybys/wasm-util": {
@@ -850,12 +850,14 @@
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-			"integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+			"integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
@@ -1039,6 +1041,8 @@
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"license": "MIT",
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
@@ -1127,6 +1131,8 @@
 		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
@@ -1237,6 +1243,8 @@
 		},
 		"node_modules/es-set-tostringtag": {
 			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -1381,6 +1389,8 @@
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
 			"funding": [
 				{
 					"type": "individual",
@@ -1398,31 +1408,38 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.2",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {
 				"node": ">= 6"
 			}
 		},
-		"node_modules/form-data/node_modules/mime-types": {
-			"version": "2.1.35",
+		"node_modules/form-data/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"license": "MIT",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/form-data/node_modules/mime-types/node_modules/mime-db": {
-			"version": "1.52.0",
+		"node_modules/form-data/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -1516,6 +1533,8 @@
 		},
 		"node_modules/has-tostringtag": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.3"
@@ -1784,6 +1803,8 @@
 		},
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"license": "MIT"
 		},
 		"node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.11.3",
-		"@shortcut/client": "^1.1.0",
+		"@shortcut/client": "^2.2.0",
 		"zod": "^3.24.4"
 	},
 	"scripts": {

--- a/src/client/shortcut.ts
+++ b/src/client/shortcut.ts
@@ -1,9 +1,11 @@
 import type {
 	ShortcutClient as BaseClient,
+	CreateDoc,
 	CreateEpic,
 	CreateIteration,
 	CreateStoryComment,
 	CreateStoryParams,
+	DocSlim,
 	Epic,
 	Group,
 	Iteration,
@@ -470,5 +472,14 @@ export class ShortcutClientWrapper {
 
 	async setStoryExternalLinks(storyPublicId: number, externalLinks: string[]): Promise<Story> {
 		return await this.updateStory(storyPublicId, { external_links: externalLinks });
+	}
+
+	async createDoc(params: CreateDoc): Promise<DocSlim> {
+		const response = await this.client.createDoc(params);
+		const doc = response?.data ?? null;
+
+		if (!doc) throw new Error(`Failed to create the document: ${response.status}`);
+
+		return doc;
 	}
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { ShortcutClient } from "@shortcut/client";
 import { ShortcutClientWrapper } from "@/client/shortcut";
 import { name, version } from "../package.json";
 
+import { DocumentTools } from "./tools/documents";
 import { EpicTools } from "./tools/epics";
 import { IterationTools } from "./tools/iterations";
 import { ObjectiveTools } from "./tools/objectives";
@@ -35,6 +36,7 @@ EpicTools.create(client, server);
 ObjectiveTools.create(client, server);
 TeamTools.create(client, server);
 WorkflowTools.create(client, server);
+DocumentTools.create(client, server);
 
 async function startServer() {
 	try {

--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -7,7 +7,7 @@ import type {
 	IterationSlim,
 	Member,
 	Milestone,
-	MilestoneSearchResult,
+	ObjectiveSearchResult,
 	Story,
 	StorySearchResult,
 	StorySlim,
@@ -376,7 +376,7 @@ export class BaseTools {
 			| IterationSlim
 			| Group
 			| Workflow
-			| MilestoneSearchResult
+			| ObjectiveSearchResult
 			| Milestone,
 	) {
 		if (entity.entity_type === "group") return this.getRelatedEntitiesForTeam(entity as Group);
@@ -399,7 +399,7 @@ export class BaseTools {
 			| IterationSlim
 			| Group
 			| Workflow
-			| MilestoneSearchResult
+			| ObjectiveSearchResult
 			| Milestone,
 	) {
 		if (entity.entity_type === "group") return this.getSimplifiedTeam(entity as Group);
@@ -423,7 +423,7 @@ export class BaseTools {
 			| IterationSlim
 			| Group
 			| Workflow
-			| MilestoneSearchResult
+			| ObjectiveSearchResult
 			| Milestone,
 		entityType = "entity",
 	) {
@@ -445,7 +445,7 @@ export class BaseTools {
 			| IterationSlim
 			| Group
 			| Workflow
-			| MilestoneSearchResult
+			| ObjectiveSearchResult
 			| Milestone
 		)[],
 		entityType = "entities",

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { DocSlim } from "@shortcut/client";
+import type { ShortcutClientWrapper } from "@/client/shortcut";
+import { DocumentTools } from "./documents";
+
+describe("DocumentTools", () => {
+	const mockDoc = {
+		id: "doc-123",
+		title: "Test Document",
+		app_url: "https://app.shortcut.com/workspace/write/doc-123",
+	} satisfies DocSlim;
+
+	const createMockClient = (methods = {}) =>
+		({
+			createDoc: mock(async () => mockDoc),
+			...methods,
+		}) as unknown as ShortcutClientWrapper;
+
+	describe("create method", () => {
+		test("should register the create-document tool with the server", () => {
+			const mockClient = createMockClient();
+			const mockTool = mock();
+			const mockServer = { tool: mockTool } as unknown as McpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			expect(mockTool).toHaveBeenCalledTimes(1);
+			expect(mockTool.mock.calls?.[0]?.[0]).toBe("create-document");
+			expect(mockTool.mock.calls?.[0]?.[1]).toBe(
+				"Create a new document in Shortcut with a title and content. Returns the document's id, title, and app_url. Note: Use HTML markup for the content (e.g., <p>, <h1>, <ul>, <strong>) rather than Markdown.",
+			);
+		});
+	});
+
+	describe("tool handler", () => {
+		test("should successfully create a document", async () => {
+			const createDocMock = mock(async () => mockDoc);
+			const mockClient = createMockClient({ createDoc: createDocMock });
+			const mockTool = mock();
+			const mockServer = { tool: mockTool } as unknown as McpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			// Get the handler from the registration call
+			const handler = mockTool.mock.calls?.[0]?.[3];
+			const result = await handler({ title: "Test Document", content: "Test content" });
+
+			expect(createDocMock).toHaveBeenCalledWith({
+				title: "Test Document",
+				content: "Test content",
+			});
+
+			expect(result.content[0].text).toContain("Document created successfully");
+			expect(result.content[0].text).toContain('"id": "doc-123"');
+			expect(result.content[0].text).toContain('"title": "Test Document"');
+			expect(result.content[0].text).toContain(
+				'"app_url": "https://app.shortcut.com/workspace/write/doc-123"',
+			);
+		});
+
+		test("should handle errors when document creation fails", async () => {
+			const errorMessage = "API error: Unauthorized";
+			const createDocMock = mock(async () => {
+				throw new Error(errorMessage);
+			});
+			const mockClient = createMockClient({ createDoc: createDocMock });
+			const mockTool = mock();
+			const mockServer = { tool: mockTool } as unknown as McpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			// Get the handler from the registration call
+			const handler = mockTool.mock.calls?.[0]?.[3];
+			const result = await handler({ title: "Test Document", content: "Test content" });
+
+			expect(createDocMock).toHaveBeenCalledWith({
+				title: "Test Document",
+				content: "Test content",
+			});
+
+			expect(result.content[0].text).toBe(`Failed to create document: ${errorMessage}`);
+		});
+
+		test("should handle non-Error exceptions", async () => {
+			const createDocMock = mock(async () => {
+				throw "Some string error";
+			});
+			const mockClient = createMockClient({ createDoc: createDocMock });
+			const mockTool = mock();
+			const mockServer = { tool: mockTool } as unknown as McpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			// Get the handler from the registration call
+			const handler = mockTool.mock.calls?.[0]?.[3];
+			const result = await handler({ title: "Test Document", content: "Test content" });
+
+			expect(result.content[0].text).toBe("Failed to create document: Unknown error");
+		});
+
+		test("should enforce title length constraint", async () => {
+			const mockClient = createMockClient();
+			const mockTool = mock();
+			const mockServer = { tool: mockTool } as unknown as McpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			// Get the schema from the registration call
+			const schema = mockTool.mock.calls?.[0]?.[2];
+			expect(schema.title.maxLength).toBe(256);
+		});
+	});
+});

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -1,0 +1,42 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ShortcutClientWrapper } from "@/client/shortcut";
+import { BaseTools } from "./base";
+
+export class DocumentTools extends BaseTools {
+	static create(client: ShortcutClientWrapper, server: McpServer) {
+		const tools = new DocumentTools(client);
+
+		server.tool(
+			"create-document",
+			"Create a new document in Shortcut with a title and content. Returns the document's id, title, and app_url. Note: Use HTML markup for the content (e.g., <p>, <h1>, <ul>, <strong>) rather than Markdown.",
+			{
+				title: z.string().max(256).describe("The title for the new document (max 256 characters)"),
+				content: z
+					.string()
+					.describe(
+						"The content for the new document in HTML format (e.g., <p>Hello</p>, <h1>Title</h1>, <ul><li>Item</li></ul>)",
+					),
+			},
+			async ({ title, content }) => await tools.createDocument(title, content),
+		);
+	}
+
+	private async createDocument(title: string, content: string) {
+		try {
+			const doc = await this.client.createDoc({
+				title,
+				content,
+			});
+
+			return this.toResult("Document created successfully", {
+				id: doc.id,
+				title: doc.title,
+				app_url: doc.app_url,
+			});
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : "Unknown error";
+			return this.toResult(`Failed to create document: ${errorMessage}`);
+		}
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/useshortcut/mcp-server-shortcut/issues/64.

Implement the ability to create Shortcut documents from the MCP server via `create-document` tool.

<img width="2180" height="1764" alt="CleanShot 2025-07-18 at 13 46 54@2x" src="https://github.com/user-attachments/assets/3a05e447-ddb9-4669-81cf-fa869fc7f164" />
