### PR TITLE
docs: update claude code cli command with correct env

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can either add a new MCP server from the command line:
 
 ```shell
 # Grab your Shortcut token here: https://app.shortcut.com/settings/account/api-tokens
-claude mcp add shortcut --transport=stdio -e API_KEY=$SHORTCUT_API_TOKEN -- npx -y @shortcut/mcp@latest
+claude mcp add shortcut --transport=stdio -e SHORTCUT_API_TOKEN=$SHORTCUT_API_TOKEN -- npx -y @shortcut/mcp@latest
 ```
 
 Or you can edit the local JSON file directly:


### PR DESCRIPTION
It should be `SHORTCUT_API_TOKEN` and not `API_KEY` in order to reflect the desired JSON structure, otherwise the env key will be incorrect. I've tested this change locally.