### PR TITLE
Add sub-task support with list and create tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Or you can edit the local JSON file directly:
 - **stories-remove-external-link** - Remove an external link from a Shortcut story
 - **stories-set-external-links** - Replace all external links on a story with a new set of links
 - **stories-get-by-external-link** - Find all stories that contain a specific external link
+- **stories-list-sub-tasks** - List all sub-tasks for a story with full details
+- **stories-create-sub-task** - Create a new sub-task under a parent story (inherits team/workflow from parent)
 
 ### Epics
 


### PR DESCRIPTION
## Summary
- Add `stories-list-sub-tasks` tool to list all sub-tasks for a story with full details
- Add `stories-create-sub-task` tool to create new sub-tasks under a parent story (inherits team/workflow from parent)

## Test plan
- [x] Added unit tests for both new tools
- [x] All 251 tests pass
- [x] Updated README documentation