### PR TITLE
Update `@modelcontextprotocol/sdk` to `1.25.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@shortcut/mcp",
-	"version": "0.15.2",
+	"version": "0.16.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shortcut/mcp",
-			"version": "0.15.2",
+			"version": "0.16.0",
 			"license": "MIT",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.21.1",
+				"@modelcontextprotocol/sdk": "^1.25.1",
 				"@shortcut/client": "^2.2.0",
 				"express": "^4.18.2",
 				"pino": "^9.5.0",
@@ -296,6 +296,18 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.7",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
+			"integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.12",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
@@ -336,11 +348,12 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.21.1",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.21.1.tgz",
-			"integrity": "sha512-UyLFcJLDvUuZbGnaQqXFT32CpPpGj7VS19roLut6gkQVhb439xUzYWbsUvdI3ZPL+2hnFosuugtYWE0Mcs1rmQ==",
+			"version": "1.25.1",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
+			"integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
 			"license": "MIT",
 			"dependencies": {
+				"@hono/node-server": "^1.19.7",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"content-type": "^1.0.5",
@@ -350,20 +363,26 @@
 				"eventsource-parser": "^3.0.0",
 				"express": "^5.0.1",
 				"express-rate-limit": "^7.5.0",
+				"jose": "^6.1.1",
+				"json-schema-typed": "^8.0.2",
 				"pkce-challenge": "^5.0.0",
 				"raw-body": "^3.0.0",
-				"zod": "^3.23.8",
-				"zod-to-json-schema": "^3.24.1"
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.0"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@cfworker/json-schema": "^4.1.1"
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
 			},
 			"peerDependenciesMeta": {
 				"@cfworker/json-schema": {
 					"optional": true
+				},
+				"zod": {
+					"optional": false
 				}
 			}
 		},
@@ -627,6 +646,25 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
+			"integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
+			"integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25 || ^4"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -1754,6 +1792,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
 			"integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -2043,6 +2082,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/hono": {
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.1.tgz",
+			"integrity": "sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
 		"node_modules/hookable": {
 			"version": "5.5.3",
 			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -2121,6 +2170,15 @@
 				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
+		"node_modules/jose": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+			"integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/joycon": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -2149,6 +2207,12 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -2324,6 +2388,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2564,6 +2629,7 @@
 			"integrity": "sha512-QOANlVluwwrLP5snQqKfC2lv/KJphMkjh4V0gpw0K40GdKmhd8eShIGOJNAC51idk5cn3xI08SZTRWj0R2XlDw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@oxc-project/runtime": "=0.77.2",
 				"@oxc-project/types": "=0.77.2",
@@ -3173,13 +3239,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.24.3",
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.24.1"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"typescript": "^5"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.21.1",
+		"@modelcontextprotocol/sdk": "^1.25.1",
 		"@shortcut/client": "^2.2.0",
 		"express": "^4.18.2",
 		"pino": "^9.5.0",

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -3,6 +3,7 @@ import type { DocSlim } from "@shortcut/client";
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
 import { DocumentTools } from "./documents";
+import { getTextContent } from "./utils/test-helpers";
 
 describe("DocumentTools", () => {
 	const mockDoc = {
@@ -51,10 +52,10 @@ describe("DocumentTools", () => {
 				content: "Test content",
 			});
 
-			expect(result.content[0].text).toContain("Document created successfully");
-			expect(result.content[0].text).toContain('"id": "doc-123"');
-			expect(result.content[0].text).toContain('"title": "Test Document"');
-			expect(result.content[0].text).toContain(
+			expect(getTextContent(result)).toContain("Document created successfully");
+			expect(getTextContent(result)).toContain('"id": "doc-123"');
+			expect(getTextContent(result)).toContain('"title": "Test Document"');
+			expect(getTextContent(result)).toContain(
 				'"app_url": "https://app.shortcut.com/workspace/write/doc-123"',
 			);
 		});
@@ -79,7 +80,7 @@ describe("DocumentTools", () => {
 				content: "Test content",
 			});
 
-			expect(result.content[0].text).toBe(`Failed to create document: ${errorMessage}`);
+			expect(getTextContent(result)).toBe(`Failed to create document: ${errorMessage}`);
 		});
 
 		test("should handle non-Error exceptions", async () => {
@@ -96,7 +97,7 @@ describe("DocumentTools", () => {
 			const handler = mockTool.mock.calls?.[0]?.[3];
 			const result = await handler({ title: "Test Document", content: "Test content" });
 
-			expect(result.content[0].text).toBe("Failed to create document: Unknown error");
+			expect(getTextContent(result)).toBe("Failed to create document: Unknown error");
 		});
 
 		test("should enforce title length constraint", async () => {

--- a/src/tools/epics.test.ts
+++ b/src/tools/epics.test.ts
@@ -3,6 +3,7 @@ import type { CreateEpic, Epic, Member, MemberInfo } from "@shortcut/client";
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
 import { EpicTools } from "./epics";
+import { getTextContent } from "./utils/test-helpers";
 
 describe("EpicTools", () => {
 	const mockEpics: Epic[] = [
@@ -125,8 +126,7 @@ describe("EpicTools", () => {
 			const epicTools = new EpicTools(mockClient);
 			const result = await epicTools.getEpic(1);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Epic: 1");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Epic 1"');
@@ -140,8 +140,7 @@ describe("EpicTools", () => {
 			const epicTools = new EpicTools(mockClient);
 			const result = await epicTools.getEpic(1, false);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Epic: 1");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Epic 1"');
@@ -156,8 +155,7 @@ describe("EpicTools", () => {
 			const epicTools = new EpicTools(mockClient);
 			const result = await epicTools.getEpic(3, true);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Epic: 3");
 			expect(textContent).toContain('"id": 3');
 			expect(textContent).toContain('"name": "Epic 3"');
@@ -172,8 +170,7 @@ describe("EpicTools", () => {
 			const epicTools = new EpicTools(mockClient);
 			const result = await epicTools.getEpic(2, true);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Epic: 2");
 			expect(textContent).toContain('"id": 2');
 			expect(textContent).toContain('"name": "Epic 2"');
@@ -211,8 +208,7 @@ describe("EpicTools", () => {
 			expect(mockClient.getCurrentUser).toHaveBeenCalled();
 			expect(mockClient.searchEpics).toHaveBeenCalled();
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Result (3 shown of 3 total epics found):");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Epic 1"');
@@ -230,8 +226,7 @@ describe("EpicTools", () => {
 			);
 			const result = await epicTools.searchEpics({});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Result: No epics found.");
+			expect(getTextContent(result)).toBe("Result: No epics found.");
 		});
 
 		test("should throw error when epics is null", async () => {
@@ -322,7 +317,7 @@ describe("EpicTools", () => {
 				description: "Description for Epic 1",
 			});
 
-			expect(result.content[0].text).toBe("Epic created with ID: 1.");
+			expect(getTextContent(result)).toBe("Epic created with ID: 1.");
 		});
 	});
 });

--- a/src/tools/iterations.test.ts
+++ b/src/tools/iterations.test.ts
@@ -3,6 +3,7 @@ import type { CreateIteration, Iteration, Member, MemberInfo, Story } from "@sho
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
 import { IterationTools } from "./iterations";
+import { getTextContent } from "./utils/test-helpers";
 
 describe("IterationTools", () => {
 	const mockCurrentUser = {
@@ -176,8 +177,7 @@ describe("IterationTools", () => {
 			const iterationTools = new IterationTools(mockClient);
 			const result = await iterationTools.getIterationStories(1, false);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Result (2 stories found):");
 			// Since search details might not be enabled, just check basic content
 			expect(textContent).toContain('"name": "Test Story 1"');
@@ -211,8 +211,7 @@ describe("IterationTools", () => {
 			);
 			const result = await iterationTools.searchIterations({});
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Result (2 shown of 2 total iterations found):");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Iteration 1"');
@@ -229,8 +228,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.searchIterations({});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Result: No iterations found.");
+			expect(getTextContent(result)).toBe("Result: No iterations found.");
 		});
 
 		test("should throw error when iterations search fails", async () => {
@@ -259,8 +257,7 @@ describe("IterationTools", () => {
 			);
 			const result = await iterationTools.getIteration(1, true);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Iteration: 1");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Iteration 1"');
@@ -279,8 +276,7 @@ describe("IterationTools", () => {
 			);
 			const result = await iterationTools.getIteration(1, false);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Iteration: 1");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Iteration 1"');
@@ -314,8 +310,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.getIteration(1);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toContain('"status": "completed"');
+			expect(getTextContent(result)).toContain('"status": "completed"');
 		});
 	});
 
@@ -342,7 +337,7 @@ describe("IterationTools", () => {
 				description: "Test Iteration created by the Shortcut MCP server",
 			});
 
-			expect(result.content[0].text).toBe("Iteration created with ID: 1.");
+			expect(getTextContent(result)).toBe("Iteration created with ID: 1.");
 		});
 	});
 
@@ -358,8 +353,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.getActiveIterations("team1");
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("The active iteration for the team is:");
 			expect(textContent).toContain('"name": "Iteration 1"');
 		});
@@ -374,8 +368,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.getActiveIterations("team1");
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Result: No active iterations found for team.");
+			expect(getTextContent(result)).toBe("Result: No active iterations found for team.");
 		});
 
 		test("should throw error when team not found", async () => {
@@ -407,8 +400,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.getActiveIterations();
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("You have 2 active iterations for your teams:");
 			expect(textContent).toContain('"name": "Iteration 1"');
 			expect(textContent).toContain('"name": "Iteration 2"');
@@ -424,8 +416,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.getActiveIterations();
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe(
+			expect(getTextContent(result)).toBe(
 				"Result: No active iterations found for any of your teams.",
 			);
 		});
@@ -467,8 +458,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.getUpcomingIterations("team1");
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("The next upcoming iteration for the team is:");
 			expect(textContent).toContain('"name": "Iteration 2"');
 		});
@@ -483,8 +473,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.getUpcomingIterations("team1");
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Result: No upcoming iterations found for team.");
+			expect(getTextContent(result)).toBe("Result: No upcoming iterations found for team.");
 		});
 
 		test("should return upcoming iterations for current user's teams", async () => {
@@ -504,8 +493,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.getUpcomingIterations();
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("The upcoming iterations for all your teams are:");
 			expect(textContent).toContain('"name": "Iteration 1"');
 			expect(textContent).toContain('"name": "Iteration 2"');
@@ -521,8 +509,7 @@ describe("IterationTools", () => {
 
 			const result = await iterationTools.getUpcomingIterations();
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe(
+			expect(getTextContent(result)).toBe(
 				"Result: No upcoming iterations found for any of your teams.",
 			);
 		});

--- a/src/tools/objectives.test.ts
+++ b/src/tools/objectives.test.ts
@@ -3,6 +3,7 @@ import type { Milestone } from "@shortcut/client";
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
 import { ObjectiveTools } from "./objectives";
+import { getTextContent } from "./utils/test-helpers";
 
 describe("ObjectiveTools", () => {
 	const mockCurrentUser = {
@@ -73,8 +74,7 @@ describe("ObjectiveTools", () => {
 			const objectiveTools = new ObjectiveTools(mockClient);
 			const result = await objectiveTools.searchObjectives({});
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Result (2 shown of 2 total milestones found):");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Objective 1"');
@@ -90,8 +90,7 @@ describe("ObjectiveTools", () => {
 
 			const result = await objectiveTools.searchObjectives({});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Result: No milestones found.");
+			expect(getTextContent(result)).toBe("Result: No milestones found.");
 		});
 
 		test("should throw error when objectives search fails", async () => {
@@ -123,8 +122,7 @@ describe("ObjectiveTools", () => {
 			const objectiveTools = new ObjectiveTools(mockClient);
 			const result = await objectiveTools.getObjective(1, true);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Objective: 1");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Objective 1"');
@@ -139,8 +137,7 @@ describe("ObjectiveTools", () => {
 			const objectiveTools = new ObjectiveTools(mockClient);
 			const result = await objectiveTools.getObjective(1, false);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Objective: 1");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Objective 1"');
@@ -179,8 +176,7 @@ describe("ObjectiveTools", () => {
 
 			const result = await objectiveTools.getObjective(2, true);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toContain('"completed": true');
+			expect(getTextContent(result)).toContain('"completed": true');
 		});
 	});
 });

--- a/src/tools/stories.test.ts
+++ b/src/tools/stories.test.ts
@@ -15,6 +15,7 @@ import type {
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
 import { StoryTools } from "./stories";
+import { getTextContent } from "./utils/test-helpers";
 
 describe("StoryTools", () => {
 	const mockCurrentUser = {
@@ -203,8 +204,7 @@ describe("StoryTools", () => {
 			const storyTools = new StoryTools(mockClient);
 			const result = await storyTools.getStory(123, true);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Story: sc-123");
 			expect(textContent).toContain('"id": 123');
 			expect(textContent).toContain('"name": "Test Story 1"');
@@ -221,8 +221,7 @@ describe("StoryTools", () => {
 			const storyTools = new StoryTools(mockClient);
 			const result = await storyTools.getStory(123, false);
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Story: sc-123");
 			expect(textContent).toContain('"id": 123');
 			expect(textContent).toContain('"name": "Test Story 1"');
@@ -262,8 +261,7 @@ describe("StoryTools", () => {
 
 			const result = await storyTools.getStory(456, true);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toContain('"deadline": null');
+			expect(getTextContent(result)).toContain('"deadline": null');
 		});
 	});
 
@@ -297,8 +295,7 @@ describe("StoryTools", () => {
 			const storyTools = new StoryTools(mockClient);
 			const result = await storyTools.searchStories({});
 
-			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Result (2 shown of 2 total stories found):");
 			expect(textContent).toContain('"id": 123');
 			expect(textContent).toContain('"name": "Test Story 1"');
@@ -320,8 +317,7 @@ describe("StoryTools", () => {
 
 			const result = await storyTools.searchStories({});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Result: No stories found.");
+			expect(getTextContent(result)).toBe("Result: No stories found.");
 		});
 
 		test("should throw error when stories search fails", async () => {
@@ -366,8 +362,7 @@ describe("StoryTools", () => {
 				workflow: 1,
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Created story: sc-789");
+			expect(getTextContent(result)).toBe("Created story: sc-789");
 			expect(createStoryMock).toHaveBeenCalledTimes(1);
 			expect(createStoryMock.mock.calls?.[0]?.[0]).toMatchObject({
 				name: "New Story",
@@ -386,8 +381,7 @@ describe("StoryTools", () => {
 				team: "team1",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Created story: sc-789");
+			expect(getTextContent(result)).toBe("Created story: sc-789");
 			expect(createStoryMock).toHaveBeenCalledTimes(1);
 			expect(createStoryMock.mock.calls?.[0]?.[0]).toMatchObject({
 				name: "New Story",
@@ -452,8 +446,7 @@ describe("StoryTools", () => {
 				type: "bug",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe(
+			expect(getTextContent(result)).toBe(
 				"Updated story sc-123. Story URL: https://app.shortcut.com/test/story/123",
 			);
 			expect(updateStoryMock).toHaveBeenCalledTimes(1);
@@ -544,8 +537,7 @@ describe("StoryTools", () => {
 			}));
 			const result = await storyTools.assignCurrentUserAsOwner(123);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Assigned current user as owner of story sc-123");
+			expect(getTextContent(result)).toBe("Assigned current user as owner of story sc-123");
 			expect(updateStoryMock).toHaveBeenCalledTimes(1);
 			expect(updateStoryMock.mock.calls?.[0]?.[0]).toBe(123);
 			expect(updateStoryMock.mock.calls?.[0]?.[1]).toMatchObject({
@@ -564,8 +556,7 @@ describe("StoryTools", () => {
 
 			const result = await storyTools.assignCurrentUserAsOwner(123);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Current user is already an owner of story sc-123");
+			expect(getTextContent(result)).toBe("Current user is already an owner of story sc-123");
 			expect(updateStoryMock).not.toHaveBeenCalled();
 		});
 
@@ -605,8 +596,7 @@ describe("StoryTools", () => {
 			const storyTools = new StoryTools(mockClient);
 			const result = await storyTools.unassignCurrentUserAsOwner(123);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Unassigned current user as owner of story sc-123");
+			expect(getTextContent(result)).toBe("Unassigned current user as owner of story sc-123");
 			expect(updateStoryMock).toHaveBeenCalledTimes(1);
 			expect(updateStoryMock.mock.calls?.[0]?.[0]).toBe(123);
 			expect(updateStoryMock.mock.calls?.[0]?.[1]).toMatchObject({
@@ -625,8 +615,7 @@ describe("StoryTools", () => {
 
 			const result = await storyTools.unassignCurrentUserAsOwner(123);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Current user is not an owner of story sc-123");
+			expect(getTextContent(result)).toBe("Current user is not an owner of story sc-123");
 			expect(updateStoryMock).not.toHaveBeenCalled();
 		});
 	});
@@ -644,8 +633,7 @@ describe("StoryTools", () => {
 			const storyTools = new StoryTools(mockClient);
 			const result = await storyTools.getStoryBranchName(123);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe(
+			expect(getTextContent(result)).toBe(
 				"Branch name for story sc-123: user1/sc-123/test-story-1",
 			);
 		});
@@ -662,8 +650,7 @@ describe("StoryTools", () => {
 
 			const result = await storyTools.getStoryBranchName(123);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Branch name for story sc-123: testuser/sc-123/story-1");
+			expect(getTextContent(result)).toBe("Branch name for story sc-123: testuser/sc-123/story-1");
 		});
 
 		test("should truncate long branch names when building custom branch name", async () => {
@@ -678,8 +665,7 @@ describe("StoryTools", () => {
 
 			const result = await storyTools.getStoryBranchName(123);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe(
+			expect(getTextContent(result)).toBe(
 				"Branch name for story sc-123: testuser/sc-123/this-is-a-very-long-story-name-tha",
 			);
 		});
@@ -696,8 +682,7 @@ describe("StoryTools", () => {
 
 			const result = await storyTools.getStoryBranchName(123);
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe(
+			expect(getTextContent(result)).toBe(
 				"Branch name for story sc-123: testuser/sc-123/special-characters-_",
 			);
 		});
@@ -726,7 +711,7 @@ describe("StoryTools", () => {
 				text: "Added comment to story sc-123.",
 			});
 
-			expect(result.content[0].text).toBe(
+			expect(getTextContent(result)).toBe(
 				`Created comment on story sc-123. Comment URL: ${mockStories[0].comments[0].app_url}.`,
 			);
 			expect(createStoryCommentMock).toHaveBeenCalledTimes(1);
@@ -781,8 +766,7 @@ describe("StoryTools", () => {
 				taskDescription: "New task",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Created task for story sc-123. Task ID: 123.");
+			expect(getTextContent(result)).toBe("Created task for story sc-123. Task ID: 123.");
 			expect(addTaskMock).toHaveBeenCalledTimes(1);
 			expect(addTaskMock.mock.calls?.[0]?.[0]).toBe(123);
 			expect(addTaskMock.mock.calls?.[0]?.[1]).toMatchObject({
@@ -847,8 +831,7 @@ describe("StoryTools", () => {
 				taskOwnerIds: ["user1", "user2"],
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Updated task for story sc-123. Task ID: 1.");
+			expect(getTextContent(result)).toBe("Updated task for story sc-123. Task ID: 1.");
 			expect(updateTaskMock).toHaveBeenCalledTimes(1);
 			expect(updateTaskMock.mock.calls?.[0]?.[0]).toBe(123);
 		});
@@ -888,8 +871,7 @@ describe("StoryTools", () => {
 				isCompleted: true,
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Completed task for story sc-123. Task ID: 1.");
+			expect(getTextContent(result)).toBe("Completed task for story sc-123. Task ID: 1.");
 			expect(updateTaskMock).toHaveBeenCalledTimes(1);
 		});
 	});
@@ -918,8 +900,7 @@ describe("StoryTools", () => {
 				relationshipType: "relates to",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Added a relationship between sc-123 and sc-456.");
+			expect(getTextContent(result)).toBe("Added a relationship between sc-123 and sc-456.");
 			expect(addStoryRelationMock).toHaveBeenCalledTimes(1);
 			expect(addStoryRelationMock.mock.calls?.[0]?.[0]).toBe(123);
 		});
@@ -959,8 +940,7 @@ describe("StoryTools", () => {
 				relationshipType: "duplicates",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Marked sc-123 as a duplicate of sc-456.");
+			expect(getTextContent(result)).toBe("Marked sc-123 as a duplicate of sc-456.");
 			expect(addStoryRelationMock).toHaveBeenCalledTimes(1);
 			expect(addStoryRelationMock.mock.calls?.[0]?.[0]).toBe(123);
 		});
@@ -973,8 +953,7 @@ describe("StoryTools", () => {
 				relationshipType: "duplicated by",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Marked sc-456 as a duplicate of sc-123.");
+			expect(getTextContent(result)).toBe("Marked sc-456 as a duplicate of sc-123.");
 			expect(addStoryRelationMock).toHaveBeenCalledTimes(1);
 			expect(addStoryRelationMock.mock.calls?.[0]?.[0]).toBe(456);
 		});
@@ -987,8 +966,7 @@ describe("StoryTools", () => {
 				relationshipType: "blocks",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Marked sc-123 as a blocker to sc-456.");
+			expect(getTextContent(result)).toBe("Marked sc-123 as a blocker to sc-456.");
 			expect(addStoryRelationMock).toHaveBeenCalledTimes(1);
 			expect(addStoryRelationMock.mock.calls?.[0]?.[0]).toBe(123);
 		});
@@ -1001,8 +979,7 @@ describe("StoryTools", () => {
 				relationshipType: "blocked by",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Marked sc-456 as a blocker to sc-123.");
+			expect(getTextContent(result)).toBe("Marked sc-456 as a blocker to sc-123.");
 			expect(addStoryRelationMock).toHaveBeenCalledTimes(1);
 			expect(addStoryRelationMock.mock.calls?.[0]?.[0]).toBe(456);
 		});
@@ -1027,7 +1004,7 @@ describe("StoryTools", () => {
 			const result = await storyTools.addExternalLinkToStory(123, "https://newlink.com");
 
 			expect(addExternalLinkToStoryMock).toHaveBeenCalledWith(123, "https://newlink.com");
-			expect(result.content[0].text).toContain("Added external link to story sc-123");
+			expect(getTextContent(result)).toContain("Added external link to story sc-123");
 		});
 	});
 
@@ -1050,7 +1027,7 @@ describe("StoryTools", () => {
 			const result = await storyTools.removeExternalLinkFromStory(123, "https://example2.com");
 
 			expect(removeExternalLinkFromStoryMock).toHaveBeenCalledWith(123, "https://example2.com");
-			expect(result.content[0].text).toContain("Removed external link from story sc-123");
+			expect(getTextContent(result)).toContain("Removed external link from story sc-123");
 		});
 	});
 
@@ -1073,7 +1050,7 @@ describe("StoryTools", () => {
 			const result = await storyTools.getStoriesByExternalLink("https://example.com");
 
 			expect(getStoriesByExternalLinkMock).toHaveBeenCalledWith("https://example.com");
-			expect(result.content[0].text).toContain("Found 1 stories with external link");
+			expect(getTextContent(result)).toContain("Found 1 stories with external link");
 		});
 	});
 
@@ -1097,7 +1074,7 @@ describe("StoryTools", () => {
 			const result = await storyTools.setStoryExternalLinks(123, newLinks);
 
 			expect(setStoryExternalLinksMock).toHaveBeenCalledWith(123, newLinks);
-			expect(result.content[0].text).toContain("Set 2 external links on story sc-123");
+			expect(getTextContent(result)).toContain("Set 2 external links on story sc-123");
 		});
 
 		test("should remove all external links when empty array provided", async () => {
@@ -1110,7 +1087,7 @@ describe("StoryTools", () => {
 			const storyTools = new StoryTools(mockClientForEmpty);
 			const result = await storyTools.setStoryExternalLinks(123, []);
 
-			expect(result.content[0].text).toContain("Removed all external links from story sc-123");
+			expect(getTextContent(result)).toContain("Removed all external links from story sc-123");
 		});
 	});
 
@@ -1137,8 +1114,7 @@ describe("StoryTools", () => {
 				description: "Description for sub-task",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Created sub-task: sc-789");
+			expect(getTextContent(result)).toBe("Created sub-task: sc-789");
 			expect(createStoryMock).toHaveBeenCalledTimes(1);
 			expect(createStoryMock.mock.calls?.[0]?.[0]).toMatchObject({
 				name: "New Sub-task",
@@ -1156,8 +1132,7 @@ describe("StoryTools", () => {
 				name: "New Sub-task",
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Created sub-task: sc-789");
+			expect(getTextContent(result)).toBe("Created sub-task: sc-789");
 			expect(createStoryMock).toHaveBeenCalledTimes(1);
 			expect(createStoryMock.mock.calls?.[0]?.[0]).toMatchObject({
 				name: "New Sub-task",
@@ -1258,8 +1233,7 @@ describe("StoryTools", () => {
 				subTaskPublicId: 456,
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Added story sc-456 as a sub-task of sc-123");
+			expect(getTextContent(result)).toBe("Added story sc-456 as a sub-task of sc-123");
 			expect(updateStoryMock).toHaveBeenCalledTimes(1);
 			expect(updateStoryMock.mock.calls?.[0]?.[0]).toBe(456);
 			expect(updateStoryMock.mock.calls?.[0]?.[1]).toMatchObject({
@@ -1343,8 +1317,7 @@ describe("StoryTools", () => {
 				subTaskPublicId: 456,
 			});
 
-			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Removed story sc-456 from its parent story");
+			expect(getTextContent(result)).toBe("Removed story sc-456 from its parent story");
 			expect(updateStoryMock).toHaveBeenCalledTimes(1);
 			expect(updateStoryMock.mock.calls?.[0]?.[0]).toBe(456);
 			expect(updateStoryMock.mock.calls?.[0]?.[1]).toMatchObject({

--- a/src/tools/teams.test.ts
+++ b/src/tools/teams.test.ts
@@ -3,6 +3,7 @@ import type { Group, Member, Workflow } from "@shortcut/client";
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
 import { TeamTools } from "./teams";
+import { getTextContent } from "./utils/test-helpers";
 
 describe("TeamTools", () => {
 	const mockMembers: Member[] = [
@@ -131,7 +132,7 @@ describe("TeamTools", () => {
 			const result = await teamTools.getTeam("team1", true);
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Team: team1");
 			expect(textContent).toContain('"id": "team1"');
 			expect(textContent).toContain('"name": "Team 1"');
@@ -148,7 +149,7 @@ describe("TeamTools", () => {
 			const result = await teamTools.getTeam("nonexistent");
 
 			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Team with public ID: nonexistent not found.");
+			expect(getTextContent(result)).toBe("Team with public ID: nonexistent not found.");
 		});
 
 		test("should handle team with no members", async () => {
@@ -168,7 +169,7 @@ describe("TeamTools", () => {
 			const result = await teamTools.getTeam("team1", true);
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Team: team1");
 			expect(textContent).toContain('"id": "team1"');
 			expect(textContent).toContain('"name": "Team 1"');
@@ -201,7 +202,7 @@ describe("TeamTools", () => {
 			const result = await teamTools.getTeams();
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Result (first 2 shown of 2 total teams found):");
 			expect(textContent).toContain('"id": "team1"');
 			expect(textContent).toContain('"name": "Team 1"');
@@ -217,7 +218,7 @@ describe("TeamTools", () => {
 			const result = await teamTools.getTeams();
 
 			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("No teams found.");
+			expect(getTextContent(result)).toBe("No teams found.");
 		});
 
 		test("should handle team with no workflows", async () => {
@@ -236,7 +237,7 @@ describe("TeamTools", () => {
 			const result = await teamTools.getTeams();
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Result (first 1 shown of 1 total teams found):");
 			expect(textContent).toContain('"id": "team1"');
 			expect(textContent).toContain('"name": "Team 1"');

--- a/src/tools/user.test.ts
+++ b/src/tools/user.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, spyOn, test } from "bun:test";
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
 import { UserTools } from "./user";
+import { getTextContent } from "./utils/test-helpers";
 
 describe("UserTools", () => {
 	const mockCurrentUser = {
@@ -48,7 +49,7 @@ describe("UserTools", () => {
 			const result = await userTools.getCurrentUser();
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Current user:");
 			expect(textContent).toContain('"id": "user1"');
 			expect(textContent).toContain('"mention_name": "testuser"');
@@ -117,7 +118,7 @@ describe("UserTools", () => {
 			const result = await userTools.getCurrentUserTeams();
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain('Current user is a member of team "Engineering":');
 			expect(textContent).toContain('"id": "team1"');
 			expect(textContent).toContain('"name": "Engineering"');
@@ -135,7 +136,7 @@ describe("UserTools", () => {
 			const result = await userTools.getCurrentUserTeams();
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Current user is a member of 2 teams:");
 			expect(textContent).toContain('"id": "team1"');
 			expect(textContent).toContain('"name": "Engineering"');
@@ -152,7 +153,7 @@ describe("UserTools", () => {
 			const result = await userTools.getCurrentUserTeams();
 
 			expect(result.content[0].type).toBe("text");
-			expect(String(result.content[0].text)).toBe("Current user is not a member of any teams.");
+			expect(getTextContent(result)).toBe("Current user is not a member of any teams.");
 		});
 
 		test("should throw error when current user is not found", async () => {
@@ -211,7 +212,7 @@ describe("UserTools", () => {
 			const result = await userTools.getCurrentUserTeams();
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain('Current user is a member of team "Engineering":');
 			expect(textContent).toContain('"id": "team1"');
 			expect(textContent).toContain('"name": "Engineering"');
@@ -234,9 +235,9 @@ describe("UserTools", () => {
 			const result = await userTools.listMembers();
 
 			expect(result.content[0].type).toBe("text");
-			expect(String(result.content[0].text)).toContain("Found 2 members:");
-			expect(String(result.content[0].text)).toContain('"mention_name": "user1"');
-			expect(String(result.content[0].text)).toContain('"mention_name": "user2"');
+			expect(getTextContent(result)).toContain("Found 2 members:");
+			expect(getTextContent(result)).toContain('"mention_name": "user1"');
+			expect(getTextContent(result)).toContain('"mention_name": "user2"');
 		});
 
 		test("should propagate errors from client", async () => {

--- a/src/tools/utils/test-helpers.ts
+++ b/src/tools/utils/test-helpers.ts
@@ -1,0 +1,15 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Extracts the text content from the first content item of a CallToolResult.
+ * Throws if the content is not of type "text".
+ */
+export function getTextContent(result: CallToolResult): string {
+	const content = result.content[0];
+
+	if (content.type !== "text") {
+		throw new Error(`Expected text content but got ${content.type}`);
+	}
+
+	return content.text;
+}

--- a/src/tools/workflows.test.ts
+++ b/src/tools/workflows.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, spyOn, test } from "bun:test";
 import type { Workflow } from "@shortcut/client";
 import type { ShortcutClientWrapper } from "@/client/shortcut";
 import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
+import { getTextContent } from "./utils/test-helpers";
 import { WorkflowTools } from "./workflows";
 
 describe("WorkflowTools", () => {
@@ -126,7 +127,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getDefaultWorkflow("team1");
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain('Default workflow for team "team1" has id 200.');
 			expect(textContent).toContain('"id": 200');
 			expect(textContent).toContain('"name": "Team Workflow"');
@@ -143,7 +144,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getDefaultWorkflow("team1");
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain(
 				'No default workflow found for team with public ID "team1". The general default workflow has id 100.',
 			);
@@ -161,7 +162,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getDefaultWorkflow("nonexistent-team");
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain(
 				'No default workflow found for team with public ID "nonexistent-team". The general default workflow has id 100.',
 			);
@@ -177,7 +178,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getDefaultWorkflow();
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Default workflow has id 100.");
 			expect(textContent).toContain('"id": 100');
 			expect(textContent).toContain('"name": "Default Workflow"');
@@ -195,7 +196,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getDefaultWorkflow("team1");
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain(
 				'No default workflow found for team with public ID "team1". The general default workflow has id 100.',
 			);
@@ -210,7 +211,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getDefaultWorkflow();
 
 			expect(result.content[0].type).toBe("text");
-			expect(String(result.content[0].text)).toBe("No default workflow found.");
+			expect(getTextContent(result)).toBe("No default workflow found.");
 		});
 
 		test("should throw error when current user is not found", async () => {
@@ -233,7 +234,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getDefaultWorkflow("team1");
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain(
 				'No default workflow found for team with public ID "team1". The general default workflow has id 100.',
 			);
@@ -251,7 +252,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getWorkflow(1, true);
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Workflow: 1");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Workflow 1"');
@@ -265,7 +266,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getWorkflow(1, false);
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Workflow: 1");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Workflow 1"');
@@ -283,7 +284,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.getWorkflow(999);
 
 			expect(result.content[0].type).toBe("text");
-			expect(result.content[0].text).toBe("Workflow with public ID: 999 not found.");
+			expect(getTextContent(result)).toBe("Workflow with public ID: 999 not found.");
 		});
 	});
 
@@ -296,7 +297,7 @@ describe("WorkflowTools", () => {
 			const result = await workflowTools.listWorkflows();
 
 			expect(result.content[0].type).toBe("text");
-			const textContent = String(result.content[0].text);
+			const textContent = getTextContent(result);
 			expect(textContent).toContain("Result (first 2 shown of 2 total workflows found):");
 			expect(textContent).toContain('"id": 1');
 			expect(textContent).toContain('"name": "Workflow 1"');
@@ -313,7 +314,7 @@ describe("WorkflowTools", () => {
 		const result = await workflowTools.listWorkflows();
 
 		expect(result.content[0].type).toBe("text");
-		expect(result.content[0].text).toBe("No workflows found.");
+		expect(getTextContent(result)).toBe("No workflows found.");
 	});
 
 	test("should handle workflow with unknown default state", async () => {
@@ -335,7 +336,7 @@ describe("WorkflowTools", () => {
 		const result = await workflowTools.listWorkflows();
 
 		expect(result.content[0].type).toBe("text");
-		const textContent = String(result.content[0].text);
+		const textContent = getTextContent(result);
 		expect(textContent).toContain("Result (first 1 shown of 1 total workflows found):");
 		expect(textContent).toContain('"id": 3');
 		expect(textContent).toContain('"name": "Workflow 3"');


### PR DESCRIPTION
## Summary

- Upgrade `@modelcontextprotocol/sdk` to v1.25.1 and fix TypeScript compatibility issues caused by the new Zod v3/v4 dual support in the SDK

## Details

### TypeScript OOM Fix

The SDK upgrade introduced `ZodRawShapeCompat` and `AnySchema` types that support both Zod v3 and v4. This caused TypeScript to run out of memory during type checking due to excessively deep type instantiation when resolving the generic `ToolCallback<Args>` type.

**Fix:** Replaced the SDK's `ToolCallback` type with simplified custom callback types (`NoArgsCallback` and `WithArgsCallback`) in `CustomMcpServer.ts` that use Zod's native `ZodRawShape` instead of the SDK's complex union types.

### Test File Updates

The SDK's `CallToolResult.content` is now a union type that includes `text`, `image`, `audio`, and `resource` content types. Tests were accessing `.text` directly without type narrowing.

**Fix:** Added a `getTextContent()` helper in `src/tools/utils/test-helpers.ts` and updated all affected test files to use it for proper type narrowing.