### PR TITLE
Revert back to GitHub container for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write # Required for OIDC
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "22.x"
+          registry-url: "https://registry.npmjs.org"
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
         run: npm install -g npm@latest


### PR DESCRIPTION
Blacksmith doesn't allow us to use OIDC for publishing to npm as provenance is only working for GitHub-hosted containers.