### PR TITLE
Feature - Create Label + List Labels Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Or you can edit the local JSON file directly:
 - **stories-set-external-links** - Replace all external links on a story with a new set of links
 - **stories-get-by-external-link** - Find all stories that contain a specific external link
 
+### Labels
+- **labels-list** - List all labels in the Shortcut workspace.
+- **labels-create** - Create a new label in Shortcut.
+
 ### Epics
 
 - **epics-get-by-id** - Get a Shortcut epic by ID
@@ -227,6 +231,7 @@ The following values are accepted in addition to the full tool names listed abov
 - `stories`
 - `epics`
 - `iterations`
+- `labels`
 - `objectives`
 - `teams`
 - `workflows`

--- a/package-lock.json
+++ b/package-lock.json
@@ -643,7 +643,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
 			"integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -1811,7 +1810,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
 			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -2413,7 +2411,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2687,7 +2684,6 @@
 			"integrity": "sha512-QOANlVluwwrLP5snQqKfC2lv/KJphMkjh4V0gpw0K40GdKmhd8eShIGOJNAC51idk5cn3xI08SZTRWj0R2XlDw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@oxc-project/runtime": "=0.77.2",
 				"@oxc-project/types": "=0.77.2",

--- a/src/client/shortcut.ts
+++ b/src/client/shortcut.ts
@@ -6,6 +6,7 @@ import type {
 	CreateDoc,
 	CreateEpic,
 	CreateIteration,
+	CreateLabelParams,
 	CreateStoryComment,
 	CreateStoryParams,
 	CustomField,
@@ -14,6 +15,7 @@ import type {
 	Group,
 	Iteration,
 	IterationSlim,
+	Label,
 	Member,
 	MemberInfo,
 	Story,
@@ -613,5 +615,21 @@ export class ShortcutClientWrapper {
 	async getCustomFields() {
 		await this.loadCustomFields();
 		return Array.from(this.customFieldCache.values());
+	}
+
+	async listLabels(): Promise<Label[]> {
+		const response = await this.client.listLabels({
+			slim: false,
+		});
+		return response?.data ?? [];
+	}
+
+	async createLabel(params: CreateLabelParams): Promise<Label> {
+		const response = await this.client.createLabel(params);
+		const label = response?.data ?? null;
+
+		if (!label) throw new Error(`Failed to create the label: ${response.status}`);
+
+		return label;
 	}
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { CustomMcpServer } from "./mcp/CustomMcpServer";
 import { DocumentTools } from "./tools/documents";
 import { EpicTools } from "./tools/epics";
 import { IterationTools } from "./tools/iterations";
+import { LabelTools } from "./tools/labels";
 import { ObjectiveTools } from "./tools/objectives";
 import { StoryTools } from "./tools/stories";
 import { TeamTools } from "./tools/teams";
@@ -51,6 +52,7 @@ ObjectiveTools.create(client, server);
 TeamTools.create(client, server);
 WorkflowTools.create(client, server);
 DocumentTools.create(client, server);
+LabelTools.create(client, server);
 
 async function startServer() {
 	try {

--- a/src/tools/labels.test.ts
+++ b/src/tools/labels.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CreateLabelParams, Label } from "@shortcut/client";
+import type { ShortcutClientWrapper } from "@/client/shortcut";
+import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
+import { LabelTools } from "./labels";
+import { getTextContent } from "./utils/test-helpers";
+
+describe("LabelTools", () => {
+	const mockLabels: Label[] = [
+		{
+			entity_type: "label",
+			id: 1,
+			name: "bug",
+			color: "#ff0000",
+			description: "Bug label",
+			archived: false,
+			app_url: "https://app.shortcut.com/test/label/1",
+			global_id: "global-1",
+			created_at: "2024-01-01T00:00:00Z",
+			updated_at: "2024-01-01T00:00:00Z",
+			external_id: null,
+			stats: {
+				num_stories: 5,
+				num_epics: 2,
+			},
+		} as unknown as Label,
+		{
+			entity_type: "label",
+			id: 2,
+			name: "feature",
+			color: "#00ff00",
+			description: "Feature label",
+			archived: false,
+			app_url: "https://app.shortcut.com/test/label/2",
+			global_id: "global-2",
+			created_at: "2024-01-02T00:00:00Z",
+			updated_at: "2024-01-02T00:00:00Z",
+			external_id: null,
+			stats: {
+				num_stories: 10,
+				num_epics: 3,
+			},
+		} as unknown as Label,
+		{
+			entity_type: "label",
+			id: 3,
+			name: "archived-label",
+			color: "#0000ff",
+			description: "Archived label",
+			archived: true,
+			app_url: "https://app.shortcut.com/test/label/3",
+			global_id: "global-3",
+			created_at: "2024-01-03T00:00:00Z",
+			updated_at: "2024-01-03T00:00:00Z",
+			external_id: null,
+			stats: {
+				num_stories: 0,
+				num_epics: 0,
+			},
+		} as unknown as Label,
+	];
+
+	const createMockClient = (methods?: object) =>
+		({
+			...methods,
+		}) as unknown as ShortcutClientWrapper;
+
+	describe("create method", () => {
+		test("should register the correct tools with the server", () => {
+			const mockClient = createMockClient();
+			const mockToolRead = mock();
+			const mockToolWrite = mock();
+			const mockServer = {
+				addToolWithReadAccess: mockToolRead,
+				addToolWithWriteAccess: mockToolWrite,
+			} as unknown as CustomMcpServer;
+
+			LabelTools.create(mockClient, mockServer);
+
+			expect(mockToolRead).toHaveBeenCalledTimes(1);
+			expect(mockToolRead.mock.calls?.[0]?.[0]).toBe("labels-list");
+
+			expect(mockToolWrite).toHaveBeenCalledTimes(1);
+			expect(mockToolWrite.mock.calls?.[0]?.[0]).toBe("labels-create");
+		});
+	});
+
+	describe("listLabels method", () => {
+		const listLabelsMock = mock(async () => mockLabels);
+
+		beforeEach(() => {
+			listLabelsMock.mockClear();
+		});
+
+		test("should return formatted list of labels when labels exist", async () => {
+			const mockClient = createMockClient({ listLabels: listLabelsMock });
+			const labelTools = new LabelTools(mockClient);
+			const result = await labelTools.listLabels();
+
+			expect(listLabelsMock).toHaveBeenCalled();
+
+			const textContent = getTextContent(result);
+			expect(textContent).toContain("Result (3 labels found):");
+			expect(textContent).toContain('"id": 1');
+			expect(textContent).toContain('"name": "bug"');
+			expect(textContent).toContain('"color": "#ff0000"');
+			expect(textContent).toContain('"id": 2');
+			expect(textContent).toContain('"name": "feature"');
+			expect(textContent).toContain('"id": 3');
+			expect(textContent).toContain('"name": "archived-label"');
+			expect(textContent).toContain('"archived": true');
+		});
+
+		test("should return no labels found message when no labels exist", async () => {
+			const emptyListMock = mock(async () => []);
+			const mockClient = createMockClient({ listLabels: emptyListMock });
+			const labelTools = new LabelTools(mockClient);
+			const result = await labelTools.listLabels();
+
+			expect(getTextContent(result)).toBe("Result: No labels found.");
+		});
+
+		test("should return simplified label fields", async () => {
+			const mockClient = createMockClient({ listLabels: listLabelsMock });
+			const labelTools = new LabelTools(mockClient);
+			const result = await labelTools.listLabels();
+
+			const textContent = getTextContent(result);
+
+			// Should contain simplified fields
+			expect(textContent).toContain('"id"');
+			expect(textContent).toContain('"name"');
+			expect(textContent).toContain('"app_url"');
+			expect(textContent).toContain('"color"');
+			expect(textContent).toContain('"description"');
+			expect(textContent).toContain('"archived"');
+
+			// Should NOT contain raw API fields that are excluded
+			expect(textContent).not.toContain('"entity_type"');
+			expect(textContent).not.toContain('"global_id"');
+			expect(textContent).not.toContain('"created_at"');
+		});
+
+		test("should handle labels with null color and description", async () => {
+			const labelsWithNulls: Label[] = [
+				{
+					entity_type: "label",
+					id: 4,
+					name: "minimal-label",
+					color: null,
+					description: null,
+					archived: false,
+					app_url: "https://app.shortcut.com/test/label/4",
+					global_id: "global-4",
+					created_at: "2024-01-04T00:00:00Z",
+					updated_at: "2024-01-04T00:00:00Z",
+					external_id: null,
+					stats: {
+						num_stories: 0,
+						num_epics: 0,
+					},
+				} as unknown as Label,
+			];
+
+			const nullLabelsMock = mock(async () => labelsWithNulls);
+			const mockClient = createMockClient({ listLabels: nullLabelsMock });
+			const labelTools = new LabelTools(mockClient);
+			const result = await labelTools.listLabels();
+
+			const textContent = getTextContent(result);
+			expect(textContent).toContain('"name": "minimal-label"');
+			expect(textContent).toContain('"color": null');
+			expect(textContent).toContain('"description": null');
+		});
+	});
+
+	describe("createLabel method", () => {
+		const createLabelMock = mock(async (_: CreateLabelParams) => ({
+			entity_type: "label",
+			id: 10,
+			name: "new-label",
+			color: "#ff5500",
+			description: "A new label",
+			archived: false,
+			app_url: "https://app.shortcut.com/test/label/10",
+			global_id: "global-10",
+			created_at: "2024-01-10T00:00:00Z",
+			updated_at: "2024-01-10T00:00:00Z",
+			external_id: null,
+			stats: {
+				num_stories: 0,
+				num_epics: 0,
+			},
+		}));
+
+		beforeEach(() => {
+			createLabelMock.mockClear();
+		});
+
+		test("should create label with all parameters", async () => {
+			const mockClient = createMockClient({ createLabel: createLabelMock });
+			const labelTools = new LabelTools(mockClient);
+			const result = await labelTools.createLabel({
+				name: "new-label",
+				color: "#ff5500",
+				description: "A new label",
+			});
+
+			expect(createLabelMock).toHaveBeenCalledWith({
+				name: "new-label",
+				color: "#ff5500",
+				description: "A new label",
+			});
+
+			const textContent = getTextContent(result);
+			expect(textContent).toContain("Label created with ID: 10.");
+			expect(textContent).toContain('"id": 10');
+			expect(textContent).toContain('"name": "new-label"');
+			expect(textContent).toContain('"color": "#ff5500"');
+			expect(textContent).toContain('"description": "A new label"');
+		});
+
+		test("should create label with only required name parameter", async () => {
+			const mockClient = createMockClient({ createLabel: createLabelMock });
+			const labelTools = new LabelTools(mockClient);
+			await labelTools.createLabel({
+				name: "minimal-label",
+			});
+
+			expect(createLabelMock).toHaveBeenCalledWith({
+				name: "minimal-label",
+				color: undefined,
+				description: undefined,
+			});
+		});
+
+		test("should create label with name and color only", async () => {
+			const mockClient = createMockClient({ createLabel: createLabelMock });
+			const labelTools = new LabelTools(mockClient);
+			await labelTools.createLabel({
+				name: "colored-label",
+				color: "#00ff00",
+			});
+
+			expect(createLabelMock).toHaveBeenCalledWith({
+				name: "colored-label",
+				color: "#00ff00",
+				description: undefined,
+			});
+		});
+
+		test("should create label with name and description only", async () => {
+			const mockClient = createMockClient({ createLabel: createLabelMock });
+			const labelTools = new LabelTools(mockClient);
+			await labelTools.createLabel({
+				name: "described-label",
+				description: "A label with description",
+			});
+
+			expect(createLabelMock).toHaveBeenCalledWith({
+				name: "described-label",
+				color: undefined,
+				description: "A label with description",
+			});
+		});
+
+		test("should throw error when label creation fails", async () => {
+			const failingMock = mock(async () => {
+				throw new Error("Failed to create the label: 400");
+			});
+			const mockClient = createMockClient({ createLabel: failingMock });
+			const labelTools = new LabelTools(mockClient);
+
+			await expect(() => labelTools.createLabel({ name: "failing-label" })).toThrow(
+				"Failed to create the label: 400",
+			);
+		});
+	});
+});

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -1,0 +1,85 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { Label } from "@shortcut/client";
+import { z } from "zod";
+import type { ShortcutClientWrapper } from "@/client/shortcut";
+import type { CustomMcpServer } from "@/mcp/CustomMcpServer";
+import { BaseTools } from "./base";
+
+/**
+ * Tools for managing Shortcut labels.
+ */
+export class LabelTools extends BaseTools {
+	static create(client: ShortcutClientWrapper, server: CustomMcpServer) {
+		const tools = new LabelTools(client);
+
+		server.addToolWithReadAccess(
+			"labels-list",
+			"List all labels in the Shortcut workspace.",
+			{},
+			async () => await tools.listLabels(),
+		);
+
+		server.addToolWithWriteAccess(
+			"labels-create",
+			"Create a new label in Shortcut.",
+			{
+				name: z.string().min(1).max(128).describe("The name of the new label. Required."),
+				color: z
+					.string()
+					.regex(/^#[a-fA-F0-9]{6}$/)
+					.optional()
+					.describe('The hex color to be displayed with the label (e.g., "#ff0000").'),
+				description: z.string().max(1024).optional().describe("A description of the label."),
+			},
+			async (params) => await tools.createLabel(params),
+		);
+
+		return tools;
+	}
+
+	private formatLabel(label: Label): Partial<Label> {
+		return {
+			id: label.id,
+			name: label.name,
+			app_url: label.app_url,
+			color: label.color ?? null,
+			description: label.description ?? null,
+			archived: label.archived,
+			stats: label.stats,
+		};
+	}
+
+	async listLabels(): Promise<CallToolResult> {
+		const labels = await this.client.listLabels();
+
+		if (!labels.length) {
+			return this.toResult("Result: No labels found.");
+		}
+
+		const formattedLabels = labels.map((label) => this.formatLabel(label));
+
+		return this.toResult(`Result (${labels.length} labels found):`, {
+			labels: formattedLabels,
+		});
+	}
+
+	async createLabel({
+		name,
+		color,
+		description,
+	}: {
+		name: string;
+		color?: string;
+		description?: string;
+	}): Promise<CallToolResult> {
+		const label = await this.client.createLabel({
+			name,
+			color,
+			description,
+		});
+
+		return this.toResult(`Label created with ID: ${label.id}.`, {
+			label: this.formatLabel(label),
+		});
+	}
+}


### PR DESCRIPTION
This PR adds new tools `labels-list` and `labels-create` to allow LLMs to list and create labels in Shortcut.

### Implementation

- Added `labels-list` tool in `labels.ts` to list all workspace labels.
- Added `labels-create` tool in `labels.ts` to create new labels with name, color, and description.
- Implemented `listLabels` and `createLabel` methods in `LabelTools` class.
- Extended the `ShortcutClientWrapper` class with `listLabels` and `createLabel` methods.
- Added corresponding test cases to ensure functionality.

### Testing

- All test cases have passed - https://d.pr/i/yKRZRB
- Verified functionality locally in VS Code:
