### PR TITLE
`documents-create` uses markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Or you can edit the local JSON file directly:
 
 ### Documents
 
-- **documents-create** - Create a new document in Shortcut with HTML content
+- **documents-create** - Create a new document in Shortcut with Markdown content
 - **documents-update** - Update content of an existing document by its ID
 - **documents-list** - List all documents in Shortcut
 - **documents-search** - Search for documents


### PR DESCRIPTION
The README says "`with HTML content`", but the tool is configured to use markdown: https://github.com/useshortcut/mcp-server-shortcut/blob/b88b178e3af04490e7c92bbda8cd28e2bad46fee/src/tools/documents.ts#L93