### PR TITLE
Fix: Update package references to match .mjs build output

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ To test your local development version of the MCP server rather than using the p
        "shortcut": {
          "command": "node",
          "args": [
-           "/path/to/your/local/mcp-server-shortcut/dist/index.js"
+           "/path/to/your/local/mcp-server-shortcut/dist/index.mjs"
          ],
          "env": {
            "SHORTCUT_API_TOKEN": "<YOUR_SHORTCUT_API_TOKEN>"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@shortcut/mcp",
-	"version": "0.19.0",
+	"version": "0.20.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shortcut/mcp",
-			"version": "0.19.0",
+			"version": "0.20.1",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.25.1",
@@ -17,7 +17,7 @@
 				"zod": "^3.24.4"
 			},
 			"bin": {
-				"mcp-server-shortcut": "dist/index.js"
+				"mcp-server-shortcut": "dist/index.mjs"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.3.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shortcut/mcp",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"description": "Shortcut MCP Server",
 	"keywords": [
 		"shortcut",
@@ -14,9 +14,9 @@
 	"license": "MIT",
 	"author": "Shortcut (https://www.shortcut.com)",
 	"type": "module",
-	"main": "dist/index.js",
+	"main": "dist/index.mjs",
 	"bin": {
-		"mcp-server-shortcut": "dist/index.js"
+		"mcp-server-shortcut": "dist/index.mjs"
 	},
 	"files": [
 		"dist"


### PR DESCRIPTION
Version 0.20.0 was broken due to tsdown 0.20.3 outputting ES modules with .mjs extensions while package.json still referenced .js files in the main and bin fields. This caused "command not found" errors when users ran the MCP server via npx.

Changes:
- Update package.json main field: dist/index.js → dist/index.mjs
- Update package.json bin field: dist/index.js → dist/index.mjs
- Update README.md development instructions to reference .mjs
- Bump version to 0.20.1

Fixes #145