### PR TITLE
Disable `fixedExtension`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@shortcut/mcp",
-	"version": "0.19.0",
+	"version": "0.20.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shortcut/mcp",
-			"version": "0.19.0",
+			"version": "0.20.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.25.1",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
   },
   outDir: 'dist',
   format: 'esm',
+  fixedExtension: false,
   clean: true,
 });


### PR DESCRIPTION
Let's disable `fixedExtension` to ensure we have matching extensions (`.js`, not `mjs`).