### PR TITLE
feat: add epics-create-comment tool

### DIFF
--- a/src/client/shortcut.ts
+++ b/src/client/shortcut.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import type {
 	ShortcutClient as BaseClient,
+	CreateCommentComment,
 	CreateDoc,
 	CreateEpic,
 	CreateEpicComment,
@@ -456,6 +457,23 @@ export class ShortcutClientWrapper {
 		const epicComment = response?.data ?? null;
 
 		if (!epicComment) throw new Error(`Failed to create the comment: ${response.status}`);
+
+		return epicComment;
+	}
+
+	async createEpicCommentComment(
+		epicPublicId: number,
+		commentPublicId: number,
+		params: CreateCommentComment,
+	): Promise<ThreadedComment> {
+		const response = await this.client.createEpicCommentComment(
+			epicPublicId,
+			commentPublicId,
+			params,
+		);
+		const epicComment = response?.data ?? null;
+
+		if (!epicComment) throw new Error(`Failed to create the comment reply: ${response.status}`);
 
 		return epicComment;
 	}

--- a/src/tools/epics.test.ts
+++ b/src/tools/epics.test.ts
@@ -488,6 +488,38 @@ describe("EpicTools", () => {
 				}),
 			).toThrow("Epic comment text is required");
 		});
+
+		test("should create a reply to an existing comment", async () => {
+			const createEpicCommentCommentMock = mock(
+				async (_epicId: number, _commentId: number, _params: { text: string }) => ({
+					id: 200,
+					text: "Reply comment",
+					app_url: "https://app.shortcut.com/test/epic/1/comments/200",
+				}),
+			);
+			const mockClient = createMockClient({
+				getEpic: getEpicMock,
+				createEpicComment: createEpicCommentMock,
+				createEpicCommentComment: createEpicCommentCommentMock,
+			});
+			const epicTools = new EpicTools(mockClient);
+			const result = await epicTools.createEpicComment({
+				epicPublicId: 1,
+				replyToCommentId: 100,
+				text: "Reply comment",
+			});
+
+			expect(getTextContent(result)).toBe(
+				"Created comment on epic 1. Comment URL: https://app.shortcut.com/test/epic/1/comments/200.",
+			);
+			expect(createEpicCommentMock).not.toHaveBeenCalled();
+			expect(createEpicCommentCommentMock).toHaveBeenCalledTimes(1);
+			expect(createEpicCommentCommentMock.mock.calls?.[0]?.[0]).toBe(1);
+			expect(createEpicCommentCommentMock.mock.calls?.[0]?.[1]).toBe(100);
+			expect(createEpicCommentCommentMock.mock.calls?.[0]?.[2]).toMatchObject({
+				text: "Reply comment",
+			});
+		});
 	});
 
 	describe("deleteEpic method", () => {

--- a/src/tools/epics.ts
+++ b/src/tools/epics.ts
@@ -98,6 +98,7 @@ export class EpicTools extends BaseTools {
 			"Add a comment to an epic.",
 			{
 				epicPublicId: z.number().positive().describe("Epic ID"),
+				replyToCommentId: z.number().positive().optional().describe("Comment ID to reply to"),
 				text: z.string().min(1).describe("Comment text"),
 			},
 			async (params) => await tools.createEpicComment(params),
@@ -208,9 +209,11 @@ export class EpicTools extends BaseTools {
 
 	async createEpicComment({
 		epicPublicId,
+		replyToCommentId,
 		text,
 	}: {
 		epicPublicId: number;
+		replyToCommentId?: number;
 		text: string;
 	}): Promise<CallToolResult> {
 		if (!epicPublicId) throw new Error("Epic public ID is required");
@@ -220,9 +223,13 @@ export class EpicTools extends BaseTools {
 		if (!epic)
 			throw new Error(`Failed to retrieve Shortcut epic with public ID: ${epicPublicId}`);
 
-		const epicComment = await this.client.createEpicComment(epicPublicId, {
-			text,
-		});
+		const epicComment = replyToCommentId
+			? await this.client.createEpicCommentComment(epicPublicId, replyToCommentId, {
+					text,
+				})
+			: await this.client.createEpicComment(epicPublicId, {
+					text,
+				});
 
 		return this.toResult(
 			`Created comment on epic ${epicPublicId}. Comment URL: ${epicComment.app_url}.`,


### PR DESCRIPTION
## Summary

- Adds `epics-create-comment` tool that allows creating comments on epics
- Mirrors the existing `stories-create-comment` tool pattern
- The `@shortcut/client` SDK already supports `createEpicComment` — this PR wires it up as an MCP tool

## Motivation

Agents can currently comment on stories but not on epics. This makes it impossible to discuss epic-level status, request closure, or coordinate with epic owners through comments. The workaround is to comment on a story within the epic, which loses context.

## Changes

- **`src/client/shortcut.ts`** — Added `createEpicComment` wrapper method (imports `CreateEpicComment` and `ThreadedComment` types)
- **`src/tools/epics.ts`** — Registered `epics-create-comment` tool with write access + implementation method
- **`src/tools/epics.test.ts`** — Added tests for the new tool (success, epic not found, empty text) and updated tool registration count

## Test plan

- [x] All 359 existing tests pass (0 fail, 7 skip)
- [x] 3 new tests added for `createEpicComment`:
  - Creates comment successfully and returns URL
  - Throws error when epic is not found
  - Throws error when comment text is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Epic comments: Users can create comments on epics, including replies to existing comments, with input validation and a returned comment URL.
* **Tests**
  * Added comprehensive tests covering successful creation, reply behavior, validation errors (missing epic or empty text), and updated registration/write-operation expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->