### PR TITLE
sc-308937: Fix disabled Allow Access button in Codex OAuth flow

### DIFF
--- a/src/auth/oauth.test.ts
+++ b/src/auth/oauth.test.ts
@@ -355,6 +355,36 @@ describe("OAuth Flow Tests", () => {
 			expect(location).toContain("redirect_uri=");
 		});
 
+		test("GET /authorize defaults scope to openid when client omits scope", async () => {
+			// First register the client to establish the redirect_uri
+			await fetch(`${baseUrl}/register`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					redirect_uris: ["http://localhost:6274/oauth/callback"],
+				}),
+			});
+
+			const params = new URLSearchParams({
+				client_id: TEST_CLIENT_ID,
+				response_type: "code",
+				redirect_uri: "http://localhost:6274/oauth/callback",
+				code_challenge: "test-code-challenge-value",
+				code_challenge_method: "S256",
+				state: "test-state-without-scope",
+			});
+
+			const res = await fetch(`${baseUrl}/authorize?${params}`, {
+				redirect: "manual",
+			});
+
+			expect(res.status).toBe(302);
+
+			const location = res.headers.get("location");
+			expect(location).toBeDefined();
+			expect(location).toContain("scope=openid");
+		});
+
 		test("GET /authorize without required params returns error", async () => {
 			const res = await fetch(`${baseUrl}/authorize`, {
 				redirect: "manual",

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -46,6 +46,8 @@ function getDefaultRedirectUris(): string[] {
 		.filter((uri) => uri.length > 0);
 }
 
+const DEFAULT_AUTHORIZATION_SCOPES = ["openid"] as const;
+
 function getStaticClientInfo(): OAuthClientInformationFull | undefined {
 	const clientId = process.env.SHORTCUT_OAUTH_CLIENT_ID;
 	const clientSecret = process.env.SHORTCUT_OAUTH_CLIENT_SECRET;
@@ -327,7 +329,9 @@ export function createOAuthProvider(
 				code_challenge_method: "S256",
 			});
 			if (params.state) searchParams.set("state", params.state);
-			if (params.scopes?.length) searchParams.set("scope", params.scopes.join(" "));
+			const scopes =
+				params.scopes && params.scopes.length > 0 ? params.scopes : DEFAULT_AUTHORIZATION_SCOPES;
+			searchParams.set("scope", scopes.join(" "));
 			if (params.resource) searchParams.set("resource", params.resource.href);
 			targetUrl.search = searchParams.toString();
 			res.redirect(targetUrl.toString());


### PR DESCRIPTION
## Summary
- Default OAuth authorize scope to openid when client omits scope
- Preserve explicitly provided scopes when present
- Add regression test for /authorize without a scope query param

## Problem
Codex CLI OAuth flow can omit the scope query parameter. Our authorize proxy forwarded no scope upstream, which left the Shortcut auth page with a disabled **Allow Access** button.

## Verification
- bun test src/auth/oauth.test.ts
- Pre-push checks ran automatically and passed (full bun test suite)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorization requests now default to the `openid` scope when no scope is explicitly specified, ensuring consistent identity authentication behavior.

* **Tests**
  * Added test coverage for default scope behavior in authorization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->