### PR TITLE
sc-308975: fix MCP transport error during Codex startup

### DIFF
--- a/src/auth/oauth.test.ts
+++ b/src/auth/oauth.test.ts
@@ -627,6 +627,26 @@ describe("OAuth Flow Tests", () => {
 				}),
 			});
 			expect(mcpRes.status).toBe(200);
+			const sessionId = mcpRes.headers.get("mcp-session-id");
+			expect(sessionId).toBeDefined();
+
+			// Step 7: Send initialized notification using the same bearer token.
+			// This verifies the server accepts follow-up session messages even if
+			// middleware refreshes token metadata internally.
+			const initializedRes = await fetch(`${baseUrl}/mcp`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${tokens.access_token}`,
+					"Mcp-Session-Id": sessionId ?? "",
+				},
+				body: JSON.stringify({
+					jsonrpc: "2.0",
+					method: "notifications/initialized",
+					params: {},
+				}),
+			});
+			expect([200, 202, 204]).toContain(initializedRes.status);
 		});
 	});
 });

--- a/src/auth/provider.test.ts
+++ b/src/auth/provider.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import {
+	InvalidGrantError,
+	InvalidTokenError,
+} from "@modelcontextprotocol/sdk/server/auth/errors.js";
 
 type HeadersMap = Record<string, unknown>;
 
@@ -130,3 +133,83 @@ describe("createOAuthProvider default verifier", () => {
 		expect(mockState.calls.length).toBe(2);
 	});
 });
+
+describe("createOAuthProvider token exchange behavior", () => {
+	beforeEach(() => {
+		process.env.SHORTCUT_OAUTH_CLIENT_ID = "test-client-id";
+		process.env.SHORTCUT_OAUTH_CLIENT_SECRET = "test-client-secret";
+		process.env.AUTH_SERVER = "api.app.shortcut-staging.com";
+	});
+
+	test("maps upstream invalid_grant refresh errors to InvalidGrantError", async () => {
+		const fetchMock = mock(async () => {
+			return new Response(
+				JSON.stringify({
+					error: "invalid_grant",
+					error_description: "Refresh token expired",
+				}),
+				{
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		});
+
+		const provider = createOAuthProvider({
+			fetch: fetchMock as unknown as FetchLike,
+			endpoints: {
+				authorizationUrl: "https://example.com/oauth/code",
+				tokenUrl: "https://example.com/oauth/token",
+			},
+		});
+
+		await expect(
+			provider.exchangeRefreshToken(
+				{
+					client_id: "test-client-id",
+					redirect_uris: [],
+				} as never,
+				"expired-refresh-token",
+			),
+		).rejects.toBeInstanceOf(InvalidGrantError);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("normalizes refresh token responses without expires_in", async () => {
+		const fetchMock = mock(async () => {
+			return new Response(
+				JSON.stringify({
+					access_token: "new-access-token",
+					refresh_token: "new-refresh-token",
+					scope: "openid",
+				}),
+				{
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		});
+
+		const provider = createOAuthProvider({
+			fetch: fetchMock as unknown as FetchLike,
+			endpoints: {
+				authorizationUrl: "https://example.com/oauth/code",
+				tokenUrl: "https://example.com/oauth/token",
+			},
+		});
+
+		const tokens = await provider.exchangeRefreshToken(
+			{
+				client_id: "test-client-id",
+				redirect_uris: [],
+			} as never,
+			"valid-refresh-token",
+		);
+
+		expect(tokens.token_type).toBe("Bearer");
+		expect(tokens.expires_in).toBe(3600);
+		expect(tokens.access_token).toBe("new-access-token");
+	});
+});
+
+type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -1,5 +1,11 @@
 import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
-import { InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import {
+	InvalidClientError,
+	InvalidGrantError,
+	InvalidRequestError,
+	InvalidTokenError,
+	ServerError,
+} from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import type {
 	AuthorizationParams,
 	OAuthServerProvider,
@@ -51,6 +57,7 @@ function getDefaultRedirectUris(): string[] {
 }
 
 const DEFAULT_AUTHORIZATION_SCOPES = ["openid"] as const;
+const DEFAULT_CLIENT_EXPIRES_IN_SECONDS = 3600;
 
 function getStaticClientInfo(): OAuthClientInformationFull | undefined {
 	const clientId = process.env.SHORTCUT_OAUTH_CLIENT_ID;
@@ -72,6 +79,44 @@ function toPublicClientInfo(client: OAuthClientInformationFull): OAuthClientInfo
 		...publicClient
 	} = client;
 	return publicClient as OAuthClientInformationFull;
+}
+
+function normalizeTokensForClient(tokens: OAuthTokens): OAuthTokens {
+	return {
+		...tokens,
+		token_type: tokens.token_type || "Bearer",
+		expires_in:
+			tokens.expires_in && tokens.expires_in > 0
+				? tokens.expires_in
+				: DEFAULT_CLIENT_EXPIRES_IN_SECONDS,
+	};
+}
+
+function throwMappedUpstreamOAuthError(status: number, body: string): never {
+	let upstreamError: { error?: string; error_description?: string } | undefined;
+	try {
+		upstreamError = JSON.parse(body) as { error?: string; error_description?: string };
+	} catch {
+		upstreamError = undefined;
+	}
+
+	const description =
+		upstreamError?.error_description || body || `OAuth upstream error (${status})`;
+	switch (upstreamError?.error) {
+		case "invalid_request":
+			throw new InvalidRequestError(description);
+		case "invalid_client":
+			throw new InvalidClientError(description);
+		case "invalid_grant":
+			throw new InvalidGrantError(description);
+		case "server_error":
+			throw new ServerError(description);
+		default:
+			if (status >= 500) {
+				throw new ServerError(description);
+			}
+			throw new InvalidGrantError(description);
+	}
 }
 
 // ============================================================================
@@ -429,10 +474,10 @@ export function createOAuthProvider(
 			if (!response.ok) {
 				const body = await response.text();
 				console.error("Token exchange failed", { status: response.status, body });
-				throw new Error(`Token exchange failed: ${response.status} ${body}`);
+				throwMappedUpstreamOAuthError(response.status, body);
 			}
 
-			const tokens = (await response.json()) as OAuthTokens;
+			const tokens = normalizeTokensForClient((await response.json()) as OAuthTokens);
 			cacheIssuedToken(tokens, client.client_id);
 			return tokens;
 		},
@@ -463,10 +508,10 @@ export function createOAuthProvider(
 			if (!response.ok) {
 				const body = await response.text();
 				console.error("Token refresh failed", { status: response.status, body });
-				throw new Error(`Token refresh failed: ${response.status}`);
+				throwMappedUpstreamOAuthError(response.status, body);
 			}
 
-			const tokens = (await response.json()) as OAuthTokens;
+			const tokens = normalizeTokensForClient((await response.json()) as OAuthTokens);
 			cacheIssuedToken(tokens, client.client_id);
 			return tokens;
 		},

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -191,12 +191,13 @@ class SessionManager {
 	add(
 		sessionId: string,
 		transport: StreamableHTTPServerTransport,
+		sessionToken: string,
 		accessToken: string,
 		clientWrapper: ShortcutClientWrapper,
 	): void {
 		this.sessions.set(sessionId, {
 			transport,
-			sessionToken: accessToken,
+			sessionToken,
 			accessToken,
 			clientWrapper,
 			createdAt: new Date(),
@@ -414,6 +415,7 @@ function createServerInstance(
 // ============================================================================
 
 async function createTransport(
+	sessionToken: string,
 	accessToken: string,
 	config: ServerConfig,
 	sessionManager: SessionManager,
@@ -425,7 +427,7 @@ async function createTransport(
 		sessionIdGenerator: () => randomUUID(),
 		onsessioninitialized: (sid): void => {
 			if (transport) {
-				sessionManager.add(sid, transport, accessToken, clientWrapper);
+				sessionManager.add(sid, transport, sessionToken, accessToken, clientWrapper);
 			}
 		},
 	});
@@ -493,14 +495,6 @@ async function handleMcpPost(
 				session.clientWrapper.updateClient(createOAuthShortcutClient(accessToken));
 			}
 
-			// If the token was refreshed by the auth middleware, update the
-			// session's ShortcutClient so tools use the fresh token.
-			if (accessToken !== session.accessToken) {
-				reqLogger.info("Token refreshed, updating session client");
-				session.accessToken = accessToken;
-				session.clientWrapper.updateClient(createOAuthShortcutClient(accessToken));
-			}
-
 			await session.transport.handleRequest(req, res, req.body);
 			return;
 		}
@@ -511,9 +505,15 @@ async function handleMcpPost(
 				sendUnauthorizedError(res, requestId);
 				return;
 			}
+			const sessionToken = extractBearerToken(req);
+			if (!sessionToken) {
+				reqLogger.warn("Missing bearer token for initialization");
+				sendUnauthorizedError(res, requestId);
+				return;
+			}
 
 			reqLogger.info("Creating session");
-			const transport = await createTransport(accessToken, config, sessionManager);
+			const transport = await createTransport(sessionToken, accessToken, config, sessionManager);
 			await transport.handleRequest(req, res, req.body);
 			return;
 		}


### PR DESCRIPTION
## Summary
- verify uncached OAuth bearer tokens using Authorization header in MCP auth provider
- keep legacy Shortcut-Token verification as fallback
- add regression tests for bearer path, fallback path, and invalid-token behavior

## Problem
Codex startup against the hosted Shortcut MCP server can fail with a transport handshake error when bearer-token verification relies only on in-memory issued-token cache across restarts / multi-instance routing.

## Verification
- bun run lint
- bun run ts
- bun test src/auth/provider.test.ts
- bun test (pre-push hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth bearer verification with automatic fallback to legacy token verification; token responses are normalized and mapped to clearer error types.
  * Session establishment now uses a session-bound token, requiring and validating it during initialization for stronger session binding.

* **Tests**
  * Added comprehensive tests covering bearer and legacy verification paths, token exchange/refresh edge cases, and session continuity for repeated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->