### PR TITLE
SC-308993: tolerate stale rotated refresh tokens

### DIFF
--- a/src/auth/provider.test.ts
+++ b/src/auth/provider.test.ts
@@ -210,6 +210,90 @@ describe("createOAuthProvider token exchange behavior", () => {
 		expect(tokens.expires_in).toBe(3600);
 		expect(tokens.access_token).toBe("new-access-token");
 	});
+
+	test("accepts a previously issued refresh token after server-side rotation", async () => {
+		let oldRefreshTokenCalls = 0;
+		const fetchMock = mock(async (_url: string | URL, init?: RequestInit) => {
+			const body = typeof init?.body === "string" ? init.body : "";
+			const params = new URLSearchParams(body);
+			const refreshToken = params.get("refresh_token");
+
+			if (refreshToken === "old-refresh-token") {
+				oldRefreshTokenCalls += 1;
+				if (oldRefreshTokenCalls === 1) {
+					return new Response(
+						JSON.stringify({
+							access_token: "access-token-2",
+							refresh_token: "new-refresh-token",
+							scope: "openid",
+						}),
+						{
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						},
+					);
+				}
+				return new Response(
+					JSON.stringify({
+						error: "invalid_grant",
+						error_description: "Refresh token already used",
+					}),
+					{
+						status: 400,
+						headers: { "Content-Type": "application/json" },
+					},
+				);
+			}
+
+			if (refreshToken === "new-refresh-token") {
+				return new Response(
+					JSON.stringify({
+						access_token: "access-token-3",
+						refresh_token: "newer-refresh-token",
+						scope: "openid",
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				);
+			}
+
+			return new Response(JSON.stringify({ error: "invalid_grant" }), {
+				status: 400,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		const provider = createOAuthProvider({
+			fetch: fetchMock as unknown as FetchLike,
+			endpoints: {
+				authorizationUrl: "https://example.com/oauth/code",
+				tokenUrl: "https://example.com/oauth/token",
+			},
+		});
+
+		const firstTokens = await provider.exchangeRefreshToken(
+			{
+				client_id: "test-client-id",
+				redirect_uris: [],
+			} as never,
+			"old-refresh-token",
+		);
+		expect(firstTokens.refresh_token).toBe("new-refresh-token");
+
+		const secondTokens = await provider.exchangeRefreshToken(
+			{
+				client_id: "test-client-id",
+				redirect_uris: [],
+			} as never,
+			"old-refresh-token",
+		);
+
+		expect(secondTokens.access_token).toBe("access-token-3");
+		expect(secondTokens.refresh_token).toBe("newer-refresh-token");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
 });
 
 type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -273,23 +273,37 @@ export function createOAuthProvider(
 		refreshToken?: string;
 	}
 	const issuedTokens = new Map<string, TokenCacheEntry>();
+	const issuedRefreshTokens = new Map<string, TokenCacheEntry>();
 
 	// Short default TTL because Shortcut's token endpoint may not return
 	// expires_in, but the actual tokens expire quickly on the API side.
 	const DEFAULT_TOKEN_TTL_SECONDS = 120;
 
-	function cacheIssuedToken(tokens: OAuthTokens, clientId: string): void {
+	function cacheIssuedToken(
+		tokens: OAuthTokens,
+		clientId: string,
+		previousRefreshToken?: string,
+	): TokenCacheEntry {
 		const expiresAt = tokens.expires_in
 			? Math.floor(Date.now() / 1000) + tokens.expires_in
 			: Math.floor(Date.now() / 1000) + DEFAULT_TOKEN_TTL_SECONDS;
 
-		issuedTokens.set(tokens.access_token, {
+		const entry: TokenCacheEntry = {
 			token: tokens.access_token,
 			clientId,
 			scopes: tokens.scope?.split(" ") ?? ["openid"],
 			expiresAt,
-			refreshToken: tokens.refresh_token,
-		});
+			refreshToken: tokens.refresh_token ?? previousRefreshToken,
+		};
+
+		issuedTokens.set(tokens.access_token, entry);
+		if (entry.refreshToken) {
+			issuedRefreshTokens.set(entry.refreshToken, entry);
+		}
+		if (previousRefreshToken) {
+			issuedRefreshTokens.set(previousRefreshToken, entry);
+		}
+		return entry;
 	}
 
 	/**
@@ -300,14 +314,15 @@ export function createOAuthProvider(
 		oldToken: string,
 		entry: TokenCacheEntry,
 	): Promise<TokenCacheEntry> {
-		if (!entry.refreshToken || !staticClient) {
+		const previousRefreshToken = entry.refreshToken;
+		if (!previousRefreshToken || !staticClient) {
 			throw new InvalidTokenError("Token expired and no refresh token available");
 		}
 
 		const params = new URLSearchParams({
 			grant_type: "refresh_token",
 			client_id: staticClient.client_id,
-			refresh_token: entry.refreshToken,
+			refresh_token: previousRefreshToken,
 		});
 		if (staticClient.client_secret) {
 			params.set("client_secret", staticClient.client_secret);
@@ -323,6 +338,7 @@ export function createOAuthProvider(
 			const body = await response.text();
 			console.error("Token refresh failed (expired-token flow)", { status: response.status, body });
 			issuedTokens.delete(oldToken);
+			issuedRefreshTokens.delete(previousRefreshToken);
 			throw new InvalidTokenError("Token refresh failed");
 		}
 
@@ -344,6 +360,10 @@ export function createOAuthProvider(
 		// Also keep the old token mapped to the new entry so the MCP client's
 		// stale token still resolves (until it re-auths or uses the new one).
 		issuedTokens.set(oldToken, newEntry);
+		if (newEntry.refreshToken) {
+			issuedRefreshTokens.set(newEntry.refreshToken, newEntry);
+		}
+		issuedRefreshTokens.set(previousRefreshToken, newEntry);
 
 		return newEntry;
 	}
@@ -488,10 +508,12 @@ export function createOAuthProvider(
 			scopes?: string[],
 			resource?: URL,
 		): Promise<OAuthTokens> {
+			const aliasedRefreshToken = issuedRefreshTokens.get(refreshToken)?.refreshToken;
+			const refreshTokenToUse = aliasedRefreshToken ?? refreshToken;
 			const params = new URLSearchParams({
 				grant_type: "refresh_token",
 				client_id: client.client_id,
-				refresh_token: refreshToken,
+				refresh_token: refreshTokenToUse,
 			});
 			if (staticClient?.client_secret) {
 				params.set("client_secret", staticClient.client_secret);
@@ -512,7 +534,7 @@ export function createOAuthProvider(
 			}
 
 			const tokens = normalizeTokensForClient((await response.json()) as OAuthTokens);
-			cacheIssuedToken(tokens, client.client_id);
+			cacheIssuedToken(tokens, client.client_id, refreshToken);
 			return tokens;
 		},
 


### PR DESCRIPTION
## Summary
- map previously-issued refresh tokens to the latest known token in OAuth provider cache
- use aliased refresh token during refresh exchange to avoid invalid_grant on stale client token
- add regression test for refresh-token rotation fallback

## Testing
- bun test src/auth/provider.test.ts
- full test suite via push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for server-side refresh token rotation scenarios.

* **Bug Fixes**
  * Enhanced token refresh handling to properly manage server-side token rotation.
  * Improved token cache management to maintain correct token mappings during refresh cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->