### PR TITLE
Fix typo in link to docs/developers.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 MCP Server for [Shortcut](https://shortcut.com) users.
 
-Links: [Local Installations](docs/local-server.md) | [ Server Developers](docs/developers.md)
+Links: [Local Installations](docs/local-server.md) | [Server Developers](docs/developers.md)
 
 ## Usage
 


### PR DESCRIPTION
Link to developer documentation at the top of readme was broken, pointing to docs/developer.md instead of docs/developers.md. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated a documentation link to point to the correct developer resource page; displayed link text unchanged.
  * No other documentation content or app behavior was modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->