### PR TITLE
fix (readme.md): Updated Claude Desktop instructions and fixed broken dev doc link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The fastest way to get started is to connect to Shortcut's hosted MCP server. No
 
 1. In the sidebar, click **Customize**.
 2. Click **Connectors**.
-3. Click **+** in the Connectors header and choose **Add custom connector** from the drop down.
+3. Click **+** in the Connectors header and choose **Add custom connector** from the drop-down.
 4. Configure the connector:
    1. Enter a name for your connector (e.g. "Shortcut MCP").
    2. Paste the Shortcut MCP server URL: `https://mcp.shortcut.com/mcp`

--- a/README.md
+++ b/README.md
@@ -53,9 +53,20 @@ For more detail on installing MCP services in VSCode see the [official VS Code M
 
 ### Claude Desktop
 
-Download the package [from this repo](https://github.com/useshortcut/mcp-server-shortcut/raw/refs/heads/main/mcp-server-shortcut.mcpb)
+The fastest way to get started is to connect to Shortcut's hosted MCP server. No API token or local setup required — authentication is handled via OAuth.
 
-Then, either double-click the icon to install or drag the package onto the client window. It should trigger the installation.
+1. In the sidebar, click **Customize**.
+2. Click **Connectors**.
+3. Click **+** in the Connectors header and choose **Add custom connector** from the drop down.
+4. Configure the connector:
+   1. Enter a name for your connector (e.g. "Shortcut MCP").
+   2. Paste the shortcut MCP server URL - `https://mcp.shortcut.com/mcp`
+   3. Click the Add button
+
+   _note: you do not need to enter OAuth information in the advanced settings, this will happen automatically._
+5. Click "connect" to authenticate and use the connector.
+
+For additional help, consult Claude desktop's documentation: [Use connectors to extend Claude's capabilities](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities).
 
 ### Other IDEs / Running Locally
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 MCP Server for [Shortcut](https://shortcut.com) users.
 
-Links: [Local Installations](docs/local-server.md) | [ Server Developers](docs/developers.md)
+Links: [Local Installations](docs/local-server.md) | [Server Developers](docs/developers.md)
 
 ## Usage
 
@@ -60,13 +60,13 @@ The fastest way to get started is to connect to Shortcut's hosted MCP server. No
 3. Click **+** in the Connectors header and choose **Add custom connector** from the drop down.
 4. Configure the connector:
    1. Enter a name for your connector (e.g. "Shortcut MCP").
-   2. Paste the shortcut MCP server URL - `https://mcp.shortcut.com/mcp`
+   2. Paste the Shortcut MCP server URL: `https://mcp.shortcut.com/mcp`
    3. Click the Add button
 
    _note: you do not need to enter OAuth information in the advanced settings, this will happen automatically._
 5. Click "connect" to authenticate and use the connector.
 
-For additional help, consult Claude desktop's documentation: [Use connectors to extend Claude's capabilities](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities).
+For more detail on installing MCP services in Claude desktop, see Anthropic's official documentation: [Use connectors to extend Claude's capabilities](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities).
 
 ### Other IDEs / Running Locally
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The fastest way to get started is to connect to Shortcut's hosted MCP server. No
    2. Paste the Shortcut MCP server URL: `https://mcp.shortcut.com/mcp`
    3. Click the Add button
 
-   _note: you do not need to enter OAuth information in the advanced settings, this will happen automatically._
-5. Click "connect" to authenticate and use the connector.
+   _Note: You do not need to enter OAuth information in the advanced settings; this happens automatically._
+5. Click **Connect** to authenticate and use the connector.
 
 For more details on installing MCP services in Claude Desktop, see Anthropic's official documentation: [Use connectors to extend Claude's capabilities](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 MCP Server for [Shortcut](https://shortcut.com) users.
 
-Links: [Local Installations](docs/local-server.md) | [ Server Developers](docs/developer.md)
+Links: [Local Installations](docs/local-server.md) | [ Server Developers](docs/developers.md)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The fastest way to get started is to connect to Shortcut's hosted MCP server. No
    _note: you do not need to enter OAuth information in the advanced settings, this will happen automatically._
 5. Click "connect" to authenticate and use the connector.
 
-For more detail on installing MCP services in Claude desktop, see Anthropic's official documentation: [Use connectors to extend Claude's capabilities](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities).
+For more details on installing MCP services in Claude Desktop, see Anthropic's official documentation: [Use connectors to extend Claude's capabilities](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities).
 
 ### Other IDEs / Running Locally
 


### PR DESCRIPTION
Dev doc link at top of readme.md was broken (typo, missing "s", developer vs developers).

Claude desktop instructions were out of date (broken link, plus desktop now supports MCP over http). Added new instructions, mimicked the wording and formatting used in the cursor instructions.

Fixes #172 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated developer docs link from "developer" to "developers"
  * Replaced direct-download Claude Desktop instructions with a connector-based installation workflow referencing official documentation
  * Rewrote Claude Desktop setup to guide users through adding a custom connector, configuring its name and server URL, and completing OAuth via advanced settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->