### PR TITLE
feat: add document delete and epic linking tools

### DIFF
--- a/src/client/shortcut.ts
+++ b/src/client/shortcut.ts
@@ -15,6 +15,7 @@ import type {
 	Doc,
 	DocSlim,
 	Epic,
+	EpicSlim,
 	Group,
 	History,
 	Iteration,
@@ -695,6 +696,23 @@ export class ShortcutClientWrapper {
 		if (response.status === 403) throw new Error("Docs feature disabled for this workspace.");
 
 		return response?.data ?? null;
+	}
+
+	async deleteDoc(docPublicId: string): Promise<void> {
+		await this.client.deleteDoc(docPublicId, { content_format: "markdown" });
+	}
+
+	async listDocumentEpics(docPublicId: string): Promise<EpicSlim[]> {
+		const response = await this.client.listDocumentEpics(docPublicId);
+		return response?.data ?? [];
+	}
+
+	async linkDocumentToEpic(docPublicId: string, epicPublicId: number): Promise<void> {
+		await this.client.linkDocumentToEpic(docPublicId, epicPublicId);
+	}
+
+	async unlinkDocumentFromEpic(docPublicId: string, epicPublicId: number): Promise<void> {
+		await this.client.unlinkDocumentFromEpic(docPublicId, epicPublicId);
 	}
 
 	async uploadFile(storyId: number, filePath: string) {

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -17,6 +17,13 @@ describe("DocumentTools", () => {
 		content_markdown: "Original content",
 	};
 
+	const mockEpic = {
+		id: 123,
+		name: "Test Epic",
+		app_url: "https://app.shortcut.com/workspace/epic/123",
+		state: "in progress",
+	};
+
 	const createMockClient = (methods = {}) =>
 		({
 			createDoc: mock(async () => mockDoc),
@@ -27,6 +34,10 @@ describe("DocumentTools", () => {
 				next_page_token: null,
 			})),
 			getDocById: mock(async () => mockDoc),
+			deleteDoc: mock(async () => {}),
+			listDocumentEpics: mock(async () => [mockEpic]),
+			linkDocumentToEpic: mock(async () => {}),
+			unlinkDocumentFromEpic: mock(async () => {}),
 			...methods,
 		}) as unknown as ShortcutClientWrapper;
 
@@ -42,14 +53,18 @@ describe("DocumentTools", () => {
 
 			DocumentTools.create(mockClient, mockServer);
 
-			expect(mockWriteTool).toHaveBeenCalledTimes(2);
+			expect(mockWriteTool).toHaveBeenCalledTimes(5);
 			expect(mockWriteTool.mock.calls?.[0]?.[0]).toBe("documents-create");
 			expect(mockWriteTool.mock.calls?.[1]?.[0]).toBe("documents-update");
-			expect(mockReadTool).toHaveBeenCalledTimes(3);
-			const [listCall, findCall, getCall] = mockReadTool.mock.calls || [];
+			expect(mockWriteTool.mock.calls?.[2]?.[0]).toBe("documents-delete");
+			expect(mockWriteTool.mock.calls?.[3]?.[0]).toBe("documents-link-epic");
+			expect(mockWriteTool.mock.calls?.[4]?.[0]).toBe("documents-unlink-epic");
+			expect(mockReadTool).toHaveBeenCalledTimes(4);
+			const [listCall, findCall, getCall, listEpicsCall] = mockReadTool.mock.calls || [];
 			expect(listCall?.[0]).toBe("documents-list");
 			expect(findCall?.[0]).toBe("documents-search");
 			expect(getCall?.[0]).toBe("documents-get-by-id");
+			expect(listEpicsCall?.[0]).toBe("documents-list-epics");
 		});
 	});
 
@@ -509,6 +524,282 @@ describe("DocumentTools", () => {
 			const result = await handler({ docId: "doc-123" });
 
 			expect(getTextContent(result)).toBe("Failed to get document: Get failed");
+		});
+
+		test("should successfully delete a document", async () => {
+			const getDocByIdMock = mock(async () => mockDocFull);
+			const deleteDocMock = mock(async () => {});
+			const mockClient = createMockClient({
+				getDocById: getDocByIdMock,
+				deleteDoc: deleteDocMock,
+			});
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[2]?.[3];
+			const result = await handler({ docId: "doc-123" });
+
+			expect(getDocByIdMock).toHaveBeenCalledWith("doc-123");
+			expect(deleteDocMock).toHaveBeenCalledWith("doc-123");
+			expect(getTextContent(result)).toContain("deleted successfully");
+			expect(getTextContent(result)).toContain("Test Document");
+		});
+
+		test("should handle document not found when deleting", async () => {
+			const getDocByIdMock = mock(async () => null);
+			const deleteDocMock = mock(async () => {});
+			const mockClient = createMockClient({
+				getDocById: getDocByIdMock,
+				deleteDoc: deleteDocMock,
+			});
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[2]?.[3];
+			const result = await handler({ docId: "missing-doc" });
+
+			expect(getDocByIdMock).toHaveBeenCalledWith("missing-doc");
+			expect(deleteDocMock).not.toHaveBeenCalled();
+			expect(getTextContent(result)).toBe("Document with ID missing-doc not found.");
+		});
+
+		test("should handle errors when deleting a document", async () => {
+			const getDocByIdMock = mock(async () => mockDocFull);
+			const deleteDocMock = mock(async () => {
+				throw new Error("Delete failed");
+			});
+			const mockClient = createMockClient({
+				getDocById: getDocByIdMock,
+				deleteDoc: deleteDocMock,
+			});
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[2]?.[3];
+			const result = await handler({ docId: "doc-123" });
+
+			expect(getTextContent(result)).toBe("Failed to delete document: Delete failed");
+		});
+
+		test("should handle non-Error exceptions when deleting", async () => {
+			const getDocByIdMock = mock(async () => mockDocFull);
+			const deleteDocMock = mock(async () => {
+				throw "Some string error";
+			});
+			const mockClient = createMockClient({
+				getDocById: getDocByIdMock,
+				deleteDoc: deleteDocMock,
+			});
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[2]?.[3];
+			const result = await handler({ docId: "doc-123" });
+
+			expect(getTextContent(result)).toBe("Failed to delete document: Unknown error");
+		});
+
+		test("should list epics linked to a document", async () => {
+			const listDocumentEpicsMock = mock(async () => [mockEpic]);
+			const mockClient = createMockClient({ listDocumentEpics: listDocumentEpicsMock });
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockReadTool.mock.calls?.[3]?.[3];
+			const result = await handler({ docId: "doc-123" });
+
+			expect(listDocumentEpicsMock).toHaveBeenCalledWith("doc-123");
+			expect(getTextContent(result)).toContain("Found 1 epic(s) linked to document doc-123.");
+			expect(getTextContent(result)).toContain('"id": 123');
+			expect(getTextContent(result)).toContain('"name": "Test Epic"');
+		});
+
+		test("should handle no epics linked to a document", async () => {
+			const listDocumentEpicsMock = mock(async () => []);
+			const mockClient = createMockClient({ listDocumentEpics: listDocumentEpicsMock });
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockReadTool.mock.calls?.[3]?.[3];
+			const result = await handler({ docId: "doc-123" });
+
+			expect(getTextContent(result)).toBe("No epics linked to document doc-123.");
+		});
+
+		test("should handle errors when listing document epics", async () => {
+			const listDocumentEpicsMock = mock(async () => {
+				throw new Error("List epics failed");
+			});
+			const mockClient = createMockClient({ listDocumentEpics: listDocumentEpicsMock });
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockReadTool.mock.calls?.[3]?.[3];
+			const result = await handler({ docId: "doc-123" });
+
+			expect(getTextContent(result)).toBe("Failed to list document epics: List epics failed");
+		});
+
+		test("should successfully link a document to an epic", async () => {
+			const linkDocumentToEpicMock = mock(async () => {});
+			const mockClient = createMockClient({ linkDocumentToEpic: linkDocumentToEpicMock });
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[3]?.[3];
+			const result = await handler({ docId: "doc-123", epicId: 456 });
+
+			expect(linkDocumentToEpicMock).toHaveBeenCalledWith("doc-123", 456);
+			expect(getTextContent(result)).toContain("Document doc-123 linked to epic 456 successfully.");
+		});
+
+		test("should handle errors when linking document to epic", async () => {
+			const linkDocumentToEpicMock = mock(async () => {
+				throw new Error("Link failed");
+			});
+			const mockClient = createMockClient({ linkDocumentToEpic: linkDocumentToEpicMock });
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[3]?.[3];
+			const result = await handler({ docId: "doc-123", epicId: 456 });
+
+			expect(getTextContent(result)).toBe("Failed to link document to epic: Link failed");
+		});
+
+		test("should handle non-Error exceptions when linking document to epic", async () => {
+			const linkDocumentToEpicMock = mock(async () => {
+				throw "Some string error";
+			});
+			const mockClient = createMockClient({ linkDocumentToEpic: linkDocumentToEpicMock });
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[3]?.[3];
+			const result = await handler({ docId: "doc-123", epicId: 456 });
+
+			expect(getTextContent(result)).toBe("Failed to link document to epic: Unknown error");
+		});
+
+		test("should successfully unlink a document from an epic", async () => {
+			const unlinkDocumentFromEpicMock = mock(async () => {});
+			const mockClient = createMockClient({ unlinkDocumentFromEpic: unlinkDocumentFromEpicMock });
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[4]?.[3];
+			const result = await handler({ docId: "doc-123", epicId: 456 });
+
+			expect(unlinkDocumentFromEpicMock).toHaveBeenCalledWith("doc-123", 456);
+			expect(getTextContent(result)).toContain(
+				"Document doc-123 unlinked from epic 456 successfully.",
+			);
+		});
+
+		test("should handle errors when unlinking document from epic", async () => {
+			const unlinkDocumentFromEpicMock = mock(async () => {
+				throw new Error("Unlink failed");
+			});
+			const mockClient = createMockClient({ unlinkDocumentFromEpic: unlinkDocumentFromEpicMock });
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[4]?.[3];
+			const result = await handler({ docId: "doc-123", epicId: 456 });
+
+			expect(getTextContent(result)).toBe("Failed to unlink document from epic: Unlink failed");
+		});
+
+		test("should handle non-Error exceptions when unlinking document from epic", async () => {
+			const unlinkDocumentFromEpicMock = mock(async () => {
+				throw "Some string error";
+			});
+			const mockClient = createMockClient({ unlinkDocumentFromEpic: unlinkDocumentFromEpicMock });
+			const mockWriteTool = mock();
+			const mockReadTool = mock();
+			const mockServer = {
+				addToolWithWriteAccess: mockWriteTool,
+				addToolWithReadAccess: mockReadTool,
+			} as unknown as CustomMcpServer;
+
+			DocumentTools.create(mockClient, mockServer);
+
+			const handler = mockWriteTool.mock.calls?.[4]?.[3];
+			const result = await handler({ docId: "doc-123", epicId: 456 });
+
+			expect(getTextContent(result)).toBe("Failed to unlink document from epic: Unknown error");
 		});
 	});
 });

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -61,6 +61,46 @@ export class DocumentTools extends BaseTools {
 			async ({ docId }: { docId: string }) => await tools.getDocumentById(docId),
 		);
 
+		server.addToolWithWriteAccess(
+			"documents-delete",
+			"Delete a document by ID.",
+			{
+				docId: z.string().describe("Document ID"),
+			},
+			async ({ docId }: { docId: string }) => await tools.deleteDocument(docId),
+		);
+
+		server.addToolWithReadAccess(
+			"documents-list-epics",
+			"List epics linked to a document.",
+			{
+				docId: z.string().describe("Document ID"),
+			},
+			async ({ docId }: { docId: string }) => await tools.listDocumentEpics(docId),
+		);
+
+		server.addToolWithWriteAccess(
+			"documents-link-epic",
+			"Link a document to an epic.",
+			{
+				docId: z.string().describe("Document ID"),
+				epicId: z.number().describe("Epic ID"),
+			},
+			async ({ docId, epicId }: { docId: string; epicId: number }) =>
+				await tools.linkDocumentToEpic(docId, epicId),
+		);
+
+		server.addToolWithWriteAccess(
+			"documents-unlink-epic",
+			"Unlink a document from an epic.",
+			{
+				docId: z.string().describe("Document ID"),
+				epicId: z.number().describe("Epic ID"),
+			},
+			async ({ docId, epicId }: { docId: string; epicId: number }) =>
+				await tools.unlinkDocumentFromEpic(docId, epicId),
+		);
+
 		return tools;
 	}
 
@@ -154,6 +194,59 @@ export class DocumentTools extends BaseTools {
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error";
 			return this.toResult(`Failed to get document: ${errorMessage}`);
+		}
+	}
+
+	private async deleteDocument(docId: string) {
+		try {
+			const doc = await this.client.getDocById(docId);
+			if (!doc) return this.toResult(`Document with ID ${docId} not found.`);
+
+			await this.client.deleteDoc(docId);
+
+			return this.toResult(`Document "${doc.title}" (${docId}) deleted successfully.`);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : "Unknown error";
+			return this.toResult(`Failed to delete document: ${errorMessage}`);
+		}
+	}
+
+	private async listDocumentEpics(docId: string) {
+		try {
+			const epics = await this.client.listDocumentEpics(docId);
+			if (!epics?.length) return this.toResult(`No epics linked to document ${docId}.`);
+			return this.toResult(
+				`Found ${epics.length} epic(s) linked to document ${docId}.`,
+				epics.map((epic) => ({
+					id: epic.id,
+					name: epic.name,
+					app_url: epic.app_url,
+					state: epic.state,
+				})),
+			);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : "Unknown error";
+			return this.toResult(`Failed to list document epics: ${errorMessage}`);
+		}
+	}
+
+	private async linkDocumentToEpic(docId: string, epicId: number) {
+		try {
+			await this.client.linkDocumentToEpic(docId, epicId);
+			return this.toResult(`Document ${docId} linked to epic ${epicId} successfully.`);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : "Unknown error";
+			return this.toResult(`Failed to link document to epic: ${errorMessage}`);
+		}
+	}
+
+	private async unlinkDocumentFromEpic(docId: string, epicId: number) {
+		try {
+			await this.client.unlinkDocumentFromEpic(docId, epicId);
+			return this.toResult(`Document ${docId} unlinked from epic ${epicId} successfully.`);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : "Unknown error";
+			return this.toResult(`Failed to unlink document from epic: ${errorMessage}`);
 		}
 	}
 }


### PR DESCRIPTION
We'd really love some API endpoints for the other doc operations - particularly adding/associating docs to collections. the doc API endpoints aren't super useful without those concepts.

In the meantime - this adds 4 new document tools to reach full parity with the Shortcut REST API v3 document endpoints:

- documents-delete: Delete a document by ID (verifies existence first)
- documents-list-epics: List epics linked to a document
- documents-link-epic: Link a document to an epic
- documents-unlink-epic: Unlink a document from an epic

Also adds corresponding wrapper methods to ShortcutClientWrapper and full test coverage for all new tools (success, not-found, error, and non-Error exception paths).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delete documents from your workspace
  * View epics linked to specific documents
  * Link documents to epics for organization
  * Unlink documents from epics as needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->