### PR TITLE
Add deprecation notice pointing to hosted MCP server

### DIFF
--- a/src/mcp/CustomMcpServer.ts
+++ b/src/mcp/CustomMcpServer.ts
@@ -41,10 +41,15 @@ type ParsedToolRegistration = {
 	hasInputSchema: boolean;
 };
 
+const DEPRECATION_NOTICE =
+	"⚠️ DEPRECATED: This self-hosted Shortcut MCP server is deprecated and no longer maintained. " +
+	"Please migrate to the official hosted server at https://mcp.shortcut.com/mcp instead.";
+
 export class CustomMcpServer extends McpServer {
 	private readonly: boolean;
 	private tools: Set<string>;
 	private authAwareToolHandlerInstalled = false;
+	private deprecationNoticeShown = false;
 	private static readonly toolAnnotationKeys = new Set([
 		"title",
 		"readOnlyHint",
@@ -359,11 +364,11 @@ export class CustomMcpServer extends McpServer {
 					// biome-ignore lint/suspicious/noExplicitAny: accessing SDK internals to customize tool errors
 					const result = await (this as any).executeToolHandler(tool, args, extra);
 					if (isTaskRequest) {
-						return result;
+						return this.withDeprecationNotice(result);
 					}
 					// biome-ignore lint/suspicious/noExplicitAny: accessing SDK internals to customize tool errors
 					await (this as any).validateToolOutput(tool, result, request.params.name);
-					return result;
+					return this.withDeprecationNotice(result);
 				} catch (error) {
 					if (error instanceof BearerAuthError) {
 						// Fallback only: request-bound token preflight should handle most
@@ -380,6 +385,21 @@ export class CustomMcpServer extends McpServer {
 				}
 			},
 		);
+	}
+
+	/**
+	 * Prepends the deprecation notice to the first successful tool result of the
+	 * session so the message surfaces to the client once. Subsequent calls and
+	 * error results are left untouched.
+	 */
+	private withDeprecationNotice(result: CallToolResult): CallToolResult {
+		if (this.deprecationNoticeShown || result?.isError) return result;
+		this.deprecationNoticeShown = true;
+		const content = Array.isArray(result?.content) ? result.content : [];
+		return {
+			...result,
+			content: [{ type: "text", text: DEPRECATION_NOTICE }, ...content],
+		};
 	}
 
 	tool(): never {

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,6 +61,10 @@ CustomFieldTools.create(client, server);
 
 async function startServer() {
 	try {
+		console.error(
+			"⚠️ DEPRECATED: This self-hosted Shortcut MCP server is deprecated and no longer maintained. " +
+				"Please migrate to the official hosted server at https://mcp.shortcut.com/mcp instead.",
+		);
 		const transport = new StdioServerTransport();
 		await server.connect(transport);
 	} catch (error) {


### PR DESCRIPTION
## Summary

This self-hosted Shortcut MCP server is deprecated and no longer maintained. This adds a notice directing users to the official hosted server at https://mcp.shortcut.com/mcp.

- Prepends the notice to the **first successful tool result of each session** via the shared `CallTool` handler in `CustomMcpServer` — covers both the stdio and HTTP servers, which each create a server instance per session.
- Errors are left untouched and don't consume the "first call" slot, so the notice survives until a real result is returned.
- Logs the notice to stderr on stdio server startup (once per process boot).

## Testing

- `bun test` — 368 pass, 0 fail
- `bun run ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation**
  * Self-hosted Shortcut MCP server now marked as deprecated
  * Deprecation warnings displayed at server startup and in tool responses
  * Notice appears once per server session to reduce repetition
  * Users directed to migrate to the hosted MCP endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->